### PR TITLE
Add Context Window Budget section

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -71,6 +71,17 @@ def cmd_scan():
     print(f"Scanning {PROJECTS_DIR} ...")
     scan()
 
+    # Snapshot context-window budgets for every known project (PR: context window)
+    try:
+        from context_scanner import snapshot_all_known
+        conn = sqlite3.connect(DB_PATH)
+        n = snapshot_all_known(conn)
+        conn.close()
+        if n:
+            print(f"Context snapshots: {n} project(s)")
+    except Exception as e:
+        print(f"  Warning: context snapshot failed: {e}")
+
 
 def cmd_today():
     conn = require_db()

--- a/context_scanner.py
+++ b/context_scanner.py
@@ -1,0 +1,320 @@
+"""
+context_scanner.py - Measure the startup "context window budget" for Claude Code projects.
+
+Claude Code loads several files into the conversation before the user types anything:
+  * Global instructions:   ~/.claude/CLAUDE.md
+  * Project instructions:  <project>/CLAUDE.md
+  * Local instructions:    <project>/CLAUDE.local.md
+  * Auto-memory index:     ~/.claude/projects/<encoded-cwd>/memory/MEMORY.md (if present)
+  * @-imports:             any `@path/to/file.md` reference inside the above files
+
+Everything else under ~/.claude/agents, ~/.claude/commands, .claude/agents,
+.claude/commands, .claude/skills (and the user-level equivalents) is "on-demand" —
+it's available to the agent but only loaded if invoked.
+
+This module:
+  1. Auto-discovers those files for a given project directory (no project-specific
+     conventions baked in).
+  2. Estimates token cost via the standard ~4 chars/token heuristic.
+  3. Persists a daily snapshot to the same SQLite DB used by the rest of claude-usage,
+     so the dashboard can render a 90-day trend.
+
+It is intentionally stdlib-only and works for any Claude Code project.
+"""
+
+import os
+import re
+import sqlite3
+from pathlib import Path
+from datetime import date
+
+# Standard 200k context window for current Claude models.
+CONTEXT_WINDOW = 200_000
+
+# Heuristic: 1 token ≈ 4 characters of English text.
+CHARS_PER_TOKEN = 4
+
+HOME = Path.home()
+GLOBAL_CLAUDE_DIR = HOME / ".claude"
+
+# Files Claude Code loads at conversation start, relative to <project>.
+ALWAYS_LOADED_PROJECT_FILES = ("CLAUDE.md", "CLAUDE.local.md")
+
+# Directories whose contents are exposed to the agent but only loaded on demand.
+ON_DEMAND_DIRS_PROJECT = (".claude/agents", ".claude/commands", ".claude/skills")
+ON_DEMAND_DIRS_GLOBAL  = ("agents", "commands", "skills")
+
+# Matches `@some/path.md` references that Claude Code expands inline.
+IMPORT_RE = re.compile(r'(?<![\w/])@([\w./\-]+\.(?:md|markdown|txt))')
+
+
+def estimate_tokens(text_or_chars):
+    if isinstance(text_or_chars, int):
+        return max(0, text_or_chars // CHARS_PER_TOKEN)
+    if not text_or_chars:
+        return 0
+    return len(text_or_chars) // CHARS_PER_TOKEN
+
+
+def _read(path):
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def _file_entry(path, kind, root):
+    if not path.exists() or not path.is_file():
+        return None
+    text = _read(path)
+    try:
+        rel = str(path.relative_to(root))
+    except ValueError:
+        rel = str(path)
+    return {
+        "path": str(path),
+        "rel": rel,
+        "kind": kind,                       # "always" | "on-demand"
+        "chars": len(text),
+        "tokens": estimate_tokens(text),
+    }
+
+
+def _resolve_imports(text, base_dirs, seen):
+    """Yield absolute Paths for @-imports in `text`, searched in `base_dirs`."""
+    for match in IMPORT_RE.findall(text or ""):
+        for base in base_dirs:
+            candidate = (base / match).resolve()
+            if candidate in seen:
+                continue
+            if candidate.exists() and candidate.is_file():
+                seen.add(candidate)
+                yield candidate
+                break
+
+
+EXCLUDE_DIRS = {"node_modules", ".git", "dist", "build", "__pycache__", ".venv", "venv"}
+
+
+def _walk_on_demand(directory, root, kind="on-demand"):
+    """Yield file entries for every text file under `directory`, skipping vendored junk."""
+    if not directory.exists() or not directory.is_dir():
+        return
+    for dirpath, dirnames, filenames in os.walk(directory):
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDE_DIRS]
+        for name in filenames:
+            if not name.lower().endswith((".md", ".markdown", ".txt")):
+                continue
+            entry = _file_entry(Path(dirpath) / name, kind, root)
+            if entry:
+                yield entry
+
+
+def scan_project(project_dir):
+    """Return a structured snapshot of the context window budget for one project.
+
+    project_dir: absolute path to the project root (the cwd Claude Code was launched in).
+    """
+    project_dir = Path(project_dir).expanduser().resolve()
+
+    files = []
+    seen = set()
+
+    # ── Always-loaded: global ─────────────────────────────────────────────────
+    global_md = GLOBAL_CLAUDE_DIR / "CLAUDE.md"
+    if global_md.exists():
+        seen.add(global_md.resolve())
+        entry = _file_entry(global_md, "always", HOME)
+        if entry:
+            entry["scope"] = "global"
+            files.append(entry)
+
+    # ── Always-loaded: project ────────────────────────────────────────────────
+    for name in ALWAYS_LOADED_PROJECT_FILES:
+        p = project_dir / name
+        if p.exists():
+            seen.add(p.resolve())
+            entry = _file_entry(p, "always", project_dir)
+            if entry:
+                entry["scope"] = "project"
+                files.append(entry)
+
+    # ── Always-loaded: auto-memory MEMORY.md (Claude Code SDK convention) ────
+    # ~/.claude/projects/<encoded-cwd>/memory/MEMORY.md
+    encoded = str(project_dir).replace("/", "-")
+    memory_md = GLOBAL_CLAUDE_DIR / "projects" / encoded / "memory" / "MEMORY.md"
+    if memory_md.exists():
+        seen.add(memory_md.resolve())
+        entry = _file_entry(memory_md, "always", HOME)
+        if entry:
+            entry["scope"] = "memory"
+            files.append(entry)
+
+    # ── Resolve @-imports recursively from already-loaded files ──────────────
+    queue = list(files)
+    while queue:
+        f = queue.pop()
+        text = _read(Path(f["path"]))
+        base_dirs = [Path(f["path"]).parent, project_dir, GLOBAL_CLAUDE_DIR]
+        for imp in _resolve_imports(text, base_dirs, seen):
+            entry = _file_entry(imp, "always", project_dir)
+            if entry:
+                entry["scope"] = "import"
+                files.append(entry)
+                queue.append(entry)
+
+    # ── On-demand: project agents/commands/skills ─────────────────────────────
+    for sub in ON_DEMAND_DIRS_PROJECT:
+        for entry in _walk_on_demand(project_dir / sub, project_dir):
+            if Path(entry["path"]).resolve() in seen:
+                continue
+            seen.add(Path(entry["path"]).resolve())
+            entry["scope"] = "project"
+            files.append(entry)
+
+    # ── On-demand: global agents/commands/skills ──────────────────────────────
+    for sub in ON_DEMAND_DIRS_GLOBAL:
+        for entry in _walk_on_demand(GLOBAL_CLAUDE_DIR / sub, HOME):
+            if Path(entry["path"]).resolve() in seen:
+                continue
+            seen.add(Path(entry["path"]).resolve())
+            entry["scope"] = "global"
+            files.append(entry)
+
+    always = [f for f in files if f["kind"] == "always"]
+    on_demand = [f for f in files if f["kind"] == "on-demand"]
+
+    always_tokens    = sum(f["tokens"] for f in always)
+    on_demand_tokens = sum(f["tokens"] for f in on_demand)
+
+    return {
+        "project_dir":      str(project_dir),
+        "context_window":   CONTEXT_WINDOW,
+        "always_tokens":    always_tokens,
+        "on_demand_tokens": on_demand_tokens,
+        "total_tokens":     always_tokens + on_demand_tokens,
+        "remaining_tokens": max(0, CONTEXT_WINDOW - always_tokens),
+        "files":            files,
+    }
+
+
+# ── Persistence ──────────────────────────────────────────────────────────────
+
+def init_context_tables(conn):
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS context_snapshots (
+            day              TEXT,
+            project_dir      TEXT,
+            always_tokens    INTEGER,
+            on_demand_tokens INTEGER,
+            file_count       INTEGER,
+            PRIMARY KEY (day, project_dir)
+        );
+        CREATE INDEX IF NOT EXISTS idx_context_day ON context_snapshots(day);
+    """)
+    conn.commit()
+
+
+def save_snapshot(conn, snapshot, day=None):
+    init_context_tables(conn)
+    day = day or date.today().isoformat()
+    conn.execute("""
+        INSERT OR REPLACE INTO context_snapshots
+            (day, project_dir, always_tokens, on_demand_tokens, file_count)
+        VALUES (?, ?, ?, ?, ?)
+    """, (
+        day,
+        snapshot["project_dir"],
+        snapshot["always_tokens"],
+        snapshot["on_demand_tokens"],
+        len(snapshot["files"]),
+    ))
+    conn.commit()
+
+
+def known_projects(conn):
+    """Return distinct project cwds Claude Code has been launched in.
+
+    Tries the `turns` table first (populated by scanner.py). Falls back to
+    decoding directory names under ~/.claude/projects/, which Claude Code
+    creates per-cwd by replacing '/' with '-'.
+    """
+    try:
+        rows = conn.execute("""
+            SELECT cwd, COUNT(*) as turns
+            FROM turns
+            WHERE cwd IS NOT NULL AND cwd != ''
+            GROUP BY cwd
+            ORDER BY turns DESC
+        """).fetchall()
+        if rows:
+            return [r[0] for r in rows]
+    except sqlite3.OperationalError:
+        pass
+
+    projects_dir = GLOBAL_CLAUDE_DIR / "projects"
+    if not projects_dir.exists():
+        return []
+    found = []
+    for d in projects_dir.iterdir():
+        if not d.is_dir():
+            continue
+        candidate = "/" + d.name.lstrip("-").replace("-", "/")
+        p = Path(candidate)
+        # Skip root and trivial paths — naive '-' → '/' decoding is ambiguous
+        # for directory names that contain hyphens. Require ≥3 path components.
+        if p.exists() and len(p.parts) >= 4:
+            found.append(candidate)
+    return sorted(set(found))
+
+
+def snapshot_all_known(conn, day=None):
+    """Snapshot every project Claude Code has been run in. Returns count."""
+    n = 0
+    for cwd in known_projects(conn):
+        if not Path(cwd).exists():
+            continue
+        snap = scan_project(cwd)
+        save_snapshot(conn, snap, day=day)
+        n += 1
+    return n
+
+
+def get_trend(conn, project_dir=None, days=90):
+    """Return [(day, always_tokens, on_demand_tokens), ...] for the trend chart."""
+    init_context_tables(conn)
+    if project_dir:
+        rows = conn.execute("""
+            SELECT day,
+                   SUM(always_tokens),
+                   SUM(on_demand_tokens)
+            FROM context_snapshots
+            WHERE project_dir = ?
+              AND day >= date('now', ?)
+            GROUP BY day
+            ORDER BY day
+        """, (project_dir, f'-{days} days')).fetchall()
+    else:
+        rows = conn.execute("""
+            SELECT day,
+                   AVG(always_tokens),
+                   AVG(on_demand_tokens)
+            FROM context_snapshots
+            WHERE day >= date('now', ?)
+            GROUP BY day
+            ORDER BY day
+        """, (f'-{days} days',)).fetchall()
+    return [
+        {"day": r[0], "always": int(r[1] or 0), "on_demand": int(r[2] or 0)}
+        for r in rows
+    ]
+
+
+if __name__ == "__main__":
+    import json, sys
+    target = sys.argv[1] if len(sys.argv) > 1 else os.getcwd()
+    snap = scan_project(target)
+    print(json.dumps({k: v for k, v in snap.items() if k != "files"}, indent=2))
+    print(f"\n{len(snap['files'])} files discovered:")
+    for f in sorted(snap["files"], key=lambda x: -x["tokens"])[:20]:
+        print(f"  {f['kind']:9}  {f['tokens']:>7,} tok  {f['rel']}")

--- a/dashboard.py
+++ b/dashboard.py
@@ -10,6 +10,8 @@ from datetime import datetime
 
 DB_PATH = Path.home() / ".claude" / "usage.db"
 
+import context_scanner
+
 
 def get_dashboard_data(db_path=DB_PATH):
     if not db_path.exists():
@@ -219,6 +221,23 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
       <tbody id="sessions-body"></tbody>
     </table>
   </div>
+  <div class="table-card">
+    <div class="section-title" style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">
+      <span>Context Window Budget</span>
+      <select id="ctx-project" style="margin-left:auto;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:4px 8px;font-size:12px;max-width:60%"></select>
+    </div>
+    <div id="ctx-meta" class="muted" style="font-size:11px;margin-bottom:12px"></div>
+    <div id="ctx-bar" style="height:14px;border-radius:7px;background:var(--bg);overflow:hidden;display:flex;margin-bottom:12px;border:1px solid var(--border)"></div>
+    <div id="ctx-stats" class="stats-row" style="margin-bottom:16px"></div>
+    <div class="chart-wrap" style="height:180px;margin-bottom:16px"><canvas id="ctx-trend"></canvas></div>
+    <details>
+      <summary style="cursor:pointer;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:8px">Files in context</summary>
+      <table style="margin-top:8px"><thead><tr>
+        <th>Kind</th><th>Scope</th><th>Path</th><th>Tokens</th>
+      </tr></thead><tbody id="ctx-files"></tbody></table>
+    </details>
+  </div>
+
   <div class="table-card">
     <div class="section-title">Cost by Model</div>
     <table>
@@ -615,6 +634,102 @@ function renderModelCostTable(byModel) {
   }).join('');
 }
 
+// ── Context Window ─────────────────────────────────────────────────────────
+let ctxSelected = null;
+
+async function loadContext(project) {
+  try {
+    const url = '/api/context' + (project ? ('?project=' + encodeURIComponent(project)) : '');
+    const r = await fetch(url);
+    const d = await r.json();
+    if (d.error) { console.error(d.error); return; }
+    renderContext(d);
+  } catch(e) { console.error(e); }
+}
+
+function shortPath(p) {
+  if (!p) return '';
+  const parts = p.split('/').filter(Boolean);
+  return parts.length > 2 ? '\u2026/' + parts.slice(-2).join('/') : p;
+}
+
+function renderContext(d) {
+  // Project picker
+  const sel = document.getElementById('ctx-project');
+  if (sel.options.length !== d.projects.length) {
+    sel.innerHTML = d.projects.map(p =>
+      `<option value="${p}">${shortPath(p)}</option>`
+    ).join('');
+    sel.onchange = () => { ctxSelected = sel.value; loadContext(ctxSelected); };
+  }
+  if (d.selected) sel.value = d.selected;
+
+  const snap = d.snapshot;
+  if (!snap) {
+    document.getElementById('ctx-meta').textContent = 'No project selected.';
+    return;
+  }
+
+  const window = d.context_window;
+  const always = snap.always_tokens;
+  const onDemand = snap.on_demand_tokens;
+  const remaining = Math.max(0, window - always);
+  const pctAlways = Math.min(100, (always / window) * 100);
+
+  document.getElementById('ctx-meta').textContent =
+    `${snap.files.length} files \u00b7 ${fmt(window)} token window \u00b7 ${shortPath(snap.project_dir)}`;
+
+  document.getElementById('ctx-bar').innerHTML =
+    `<div style="width:${pctAlways}%;background:var(--accent)" title="Always loaded: ${fmt(always)} tokens"></div>` +
+    `<div style="flex:1;background:var(--card)" title="Free: ${fmt(remaining)} tokens"></div>`;
+
+  document.getElementById('ctx-stats').innerHTML = [
+    { label: 'Always Loaded',  value: fmt(always),    sub: pctAlways.toFixed(1) + '% of window' },
+    { label: 'On-Demand',      value: fmt(onDemand),  sub: 'available, not auto-loaded' },
+    { label: 'Free',           value: fmt(remaining), sub: 'in 200k window', color: '#4ade80' },
+    { label: 'Files',          value: snap.files.length.toString(), sub: 'discovered' },
+  ].map(s => `
+    <div class="stat-card">
+      <div class="label">${s.label}</div>
+      <div class="value" style="${s.color ? 'color:' + s.color : ''}">${s.value}</div>
+      <div class="sub">${s.sub}</div>
+    </div>`).join('');
+
+  // Trend chart
+  const ctx = document.getElementById('ctx-trend').getContext('2d');
+  if (charts.ctx) charts.ctx.destroy();
+  if (d.trend.length) {
+    charts.ctx = new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: d.trend.map(t => t.day),
+        datasets: [
+          { label: 'Always loaded', data: d.trend.map(t => t.always),
+            borderColor: '#d97757', backgroundColor: 'rgba(217,119,87,0.15)', fill: true, tension: 0.25 },
+        ]
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        plugins: { legend: { labels: { color: '#8892a4' } } },
+        scales: {
+          x: { ticks: { color: '#8892a4', maxTicksLimit: 10 }, grid: { color: '#2a2d3a' } },
+          y: { ticks: { color: '#8892a4', callback: v => fmt(v) }, grid: { color: '#2a2d3a' } },
+        }
+      }
+    });
+  }
+
+  // File table — top 50 by tokens
+  const sorted = [...snap.files].sort((a,b) => b.tokens - a.tokens).slice(0, 50);
+  document.getElementById('ctx-files').innerHTML = sorted.map(f => `
+    <tr>
+      <td><span class="model-tag" style="background:${f.kind==='always'?'rgba(217,119,87,0.18)':'rgba(136,146,164,0.15)'};color:${f.kind==='always'?'var(--accent)':'var(--muted)'}">${f.kind}</span></td>
+      <td class="muted">${f.scope || ''}</td>
+      <td class="muted" style="font-family:monospace;font-size:11px">${f.rel}</td>
+      <td class="num">${fmt(f.tokens)}</td>
+    </tr>`).join('');
+}
+
 // ── Data loading ───────────────────────────────────────────────────────────
 async function loadData() {
   try {
@@ -646,7 +761,9 @@ async function loadData() {
 }
 
 loadData();
+loadContext();
 setInterval(loadData, 30000);
+setInterval(() => loadContext(ctxSelected), 60000);
 </script>
 </body>
 </html>
@@ -663,6 +780,35 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
             self.wfile.write(HTML_TEMPLATE.encode("utf-8"))
+
+        elif self.path.startswith("/api/context"):
+            from urllib.parse import urlparse, parse_qs
+            qs = parse_qs(urlparse(self.path).query)
+            project = (qs.get("project", [None])[0]) or None
+            try:
+                conn = sqlite3.connect(DB_PATH)
+                conn.row_factory = sqlite3.Row
+                projects = context_scanner.known_projects(conn)
+                # Default to most-active project if none specified
+                target = project or (projects[0] if projects else None)
+                snapshot = context_scanner.scan_project(target) if target else None
+                trend = context_scanner.get_trend(conn, project_dir=target, days=90)
+                conn.close()
+                payload = {
+                    "projects": projects,
+                    "selected": target,
+                    "snapshot": snapshot,
+                    "trend": trend,
+                    "context_window": context_scanner.CONTEXT_WINDOW,
+                }
+            except Exception as e:
+                payload = {"error": str(e)}
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
 
         elif self.path == "/api/data":
             data = get_dashboard_data()


### PR DESCRIPTION
## Summary

Adds a self-contained **Context Window Budget** section to the existing dashboard that answers a question the current tool doesn't: *how much of Claude Code's 200k context window is already burned before the user types anything?*

For each project Claude Code has been launched in, it auto-discovers the files Claude Code actually loads at conversation start, estimates their token cost, classifies them as always-loaded vs on-demand, and persists a daily snapshot so you can spot bloat creeping in over time.

This is fully generic — no project-specific conventions baked in. It works for any Claude Code user as soon as they pull and re-run `python cli.py scan`.

## What gets discovered

**Always loaded** (counted against the 200k window):
- `~/.claude/CLAUDE.md` (global instructions)
- `<project>/CLAUDE.md` and `<project>/CLAUDE.local.md`
- `~/.claude/projects/<encoded-cwd>/memory/MEMORY.md` (Claude Code SDK auto-memory)
- Any `@path/to/file.md` imports referenced inline by the above

**On-demand** (available to the agent but not auto-loaded):
- `.claude/agents/`, `.claude/commands/`, `.claude/skills/` — project-level
- `~/.claude/agents/`, `~/.claude/commands/`, `~/.claude/skills/` — global

`node_modules`, `.git`, `dist`, `build`, `__pycache__`, and venvs are excluded from the on-demand walk.

## What's added

- **`context_scanner.py`** (new) — pure stdlib. Discovery + ~4 chars/token estimation + new `context_snapshots` SQLite table + 90-day trend query. Works standalone: if `turns` is empty (first run), it falls back to decoding directory names under `~/.claude/projects/`.
- **`cli.py`** — `scan` now also writes a daily context snapshot for every known project. Failures are non-fatal.
- **`dashboard.py`** — new `/api/context` endpoint and a Context Window Budget card in the existing single-page UI:
  - project picker (defaults to most-active project)
  - horizontal usage bar (always-loaded fraction of the 200k window)
  - stat cards: Always Loaded / On-Demand / Free / File count
  - 90-day trend line chart (Chart.js, matches existing dark theme)
  - expandable file list sorted by token cost, with kind/scope tags

## Why this is useful

`CLAUDE.md` files, MEMORY indexes, and skill `SKILL.md` files all silently grow over time. Once they cross ~10–20k always-loaded tokens, every conversation starts at a meaningful disadvantage. Today there's no way to see this in claude-usage; this PR makes it a first-class metric, and the daily snapshot makes the trend visible.

## Notes

- Stdlib-only. No new dependencies.
- All new SQL is `CREATE TABLE IF NOT EXISTS` — safe on existing DBs.
- Theme/colors/component styles match the existing single-page layout (no new CSS rules added besides inline styles in the new section).
- This is PR 1 of 2. PR 2 will add a session transcript viewer + GitHub Releases section, also as standalone/generic features.

## Test plan

- [ ] Pull the branch and run `python cli.py scan` — should print `Context snapshots: N project(s)` after the normal scan output.
- [ ] Run `python cli.py dashboard` — Context Window Budget section should render below the existing tables.
- [ ] Switch projects via the dropdown — bar, stats, file list, and trend chart should all update.
- [ ] Expand "Files in context" — should list always-loaded files first, with `~/.claude/CLAUDE.md` and `<project>/CLAUDE.md` near the top.
- [ ] Re-run `scan` the next day — trend chart should pick up a second data point.