### PR TITLE
Add session transcript viewer + GitHub Releases section

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -71,6 +71,17 @@ def cmd_scan():
     print(f"Scanning {PROJECTS_DIR} ...")
     scan()
 
+    # Snapshot context-window budgets for every known project (PR: context window)
+    try:
+        from context_scanner import snapshot_all_known
+        conn = sqlite3.connect(DB_PATH)
+        n = snapshot_all_known(conn)
+        conn.close()
+        if n:
+            print(f"Context snapshots: {n} project(s)")
+    except Exception as e:
+        print(f"  Warning: context snapshot failed: {e}")
+
 
 def cmd_today():
     conn = require_db()

--- a/context_scanner.py
+++ b/context_scanner.py
@@ -1,0 +1,320 @@
+"""
+context_scanner.py - Measure the startup "context window budget" for Claude Code projects.
+
+Claude Code loads several files into the conversation before the user types anything:
+  * Global instructions:   ~/.claude/CLAUDE.md
+  * Project instructions:  <project>/CLAUDE.md
+  * Local instructions:    <project>/CLAUDE.local.md
+  * Auto-memory index:     ~/.claude/projects/<encoded-cwd>/memory/MEMORY.md (if present)
+  * @-imports:             any `@path/to/file.md` reference inside the above files
+
+Everything else under ~/.claude/agents, ~/.claude/commands, .claude/agents,
+.claude/commands, .claude/skills (and the user-level equivalents) is "on-demand" —
+it's available to the agent but only loaded if invoked.
+
+This module:
+  1. Auto-discovers those files for a given project directory (no project-specific
+     conventions baked in).
+  2. Estimates token cost via the standard ~4 chars/token heuristic.
+  3. Persists a daily snapshot to the same SQLite DB used by the rest of claude-usage,
+     so the dashboard can render a 90-day trend.
+
+It is intentionally stdlib-only and works for any Claude Code project.
+"""
+
+import os
+import re
+import sqlite3
+from pathlib import Path
+from datetime import date
+
+# Standard 200k context window for current Claude models.
+CONTEXT_WINDOW = 200_000
+
+# Heuristic: 1 token ≈ 4 characters of English text.
+CHARS_PER_TOKEN = 4
+
+HOME = Path.home()
+GLOBAL_CLAUDE_DIR = HOME / ".claude"
+
+# Files Claude Code loads at conversation start, relative to <project>.
+ALWAYS_LOADED_PROJECT_FILES = ("CLAUDE.md", "CLAUDE.local.md")
+
+# Directories whose contents are exposed to the agent but only loaded on demand.
+ON_DEMAND_DIRS_PROJECT = (".claude/agents", ".claude/commands", ".claude/skills")
+ON_DEMAND_DIRS_GLOBAL  = ("agents", "commands", "skills")
+
+# Matches `@some/path.md` references that Claude Code expands inline.
+IMPORT_RE = re.compile(r'(?<![\w/])@([\w./\-]+\.(?:md|markdown|txt))')
+
+
+def estimate_tokens(text_or_chars):
+    if isinstance(text_or_chars, int):
+        return max(0, text_or_chars // CHARS_PER_TOKEN)
+    if not text_or_chars:
+        return 0
+    return len(text_or_chars) // CHARS_PER_TOKEN
+
+
+def _read(path):
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def _file_entry(path, kind, root):
+    if not path.exists() or not path.is_file():
+        return None
+    text = _read(path)
+    try:
+        rel = str(path.relative_to(root))
+    except ValueError:
+        rel = str(path)
+    return {
+        "path": str(path),
+        "rel": rel,
+        "kind": kind,                       # "always" | "on-demand"
+        "chars": len(text),
+        "tokens": estimate_tokens(text),
+    }
+
+
+def _resolve_imports(text, base_dirs, seen):
+    """Yield absolute Paths for @-imports in `text`, searched in `base_dirs`."""
+    for match in IMPORT_RE.findall(text or ""):
+        for base in base_dirs:
+            candidate = (base / match).resolve()
+            if candidate in seen:
+                continue
+            if candidate.exists() and candidate.is_file():
+                seen.add(candidate)
+                yield candidate
+                break
+
+
+EXCLUDE_DIRS = {"node_modules", ".git", "dist", "build", "__pycache__", ".venv", "venv"}
+
+
+def _walk_on_demand(directory, root, kind="on-demand"):
+    """Yield file entries for every text file under `directory`, skipping vendored junk."""
+    if not directory.exists() or not directory.is_dir():
+        return
+    for dirpath, dirnames, filenames in os.walk(directory):
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDE_DIRS]
+        for name in filenames:
+            if not name.lower().endswith((".md", ".markdown", ".txt")):
+                continue
+            entry = _file_entry(Path(dirpath) / name, kind, root)
+            if entry:
+                yield entry
+
+
+def scan_project(project_dir):
+    """Return a structured snapshot of the context window budget for one project.
+
+    project_dir: absolute path to the project root (the cwd Claude Code was launched in).
+    """
+    project_dir = Path(project_dir).expanduser().resolve()
+
+    files = []
+    seen = set()
+
+    # ── Always-loaded: global ─────────────────────────────────────────────────
+    global_md = GLOBAL_CLAUDE_DIR / "CLAUDE.md"
+    if global_md.exists():
+        seen.add(global_md.resolve())
+        entry = _file_entry(global_md, "always", HOME)
+        if entry:
+            entry["scope"] = "global"
+            files.append(entry)
+
+    # ── Always-loaded: project ────────────────────────────────────────────────
+    for name in ALWAYS_LOADED_PROJECT_FILES:
+        p = project_dir / name
+        if p.exists():
+            seen.add(p.resolve())
+            entry = _file_entry(p, "always", project_dir)
+            if entry:
+                entry["scope"] = "project"
+                files.append(entry)
+
+    # ── Always-loaded: auto-memory MEMORY.md (Claude Code SDK convention) ────
+    # ~/.claude/projects/<encoded-cwd>/memory/MEMORY.md
+    encoded = str(project_dir).replace("/", "-")
+    memory_md = GLOBAL_CLAUDE_DIR / "projects" / encoded / "memory" / "MEMORY.md"
+    if memory_md.exists():
+        seen.add(memory_md.resolve())
+        entry = _file_entry(memory_md, "always", HOME)
+        if entry:
+            entry["scope"] = "memory"
+            files.append(entry)
+
+    # ── Resolve @-imports recursively from already-loaded files ──────────────
+    queue = list(files)
+    while queue:
+        f = queue.pop()
+        text = _read(Path(f["path"]))
+        base_dirs = [Path(f["path"]).parent, project_dir, GLOBAL_CLAUDE_DIR]
+        for imp in _resolve_imports(text, base_dirs, seen):
+            entry = _file_entry(imp, "always", project_dir)
+            if entry:
+                entry["scope"] = "import"
+                files.append(entry)
+                queue.append(entry)
+
+    # ── On-demand: project agents/commands/skills ─────────────────────────────
+    for sub in ON_DEMAND_DIRS_PROJECT:
+        for entry in _walk_on_demand(project_dir / sub, project_dir):
+            if Path(entry["path"]).resolve() in seen:
+                continue
+            seen.add(Path(entry["path"]).resolve())
+            entry["scope"] = "project"
+            files.append(entry)
+
+    # ── On-demand: global agents/commands/skills ──────────────────────────────
+    for sub in ON_DEMAND_DIRS_GLOBAL:
+        for entry in _walk_on_demand(GLOBAL_CLAUDE_DIR / sub, HOME):
+            if Path(entry["path"]).resolve() in seen:
+                continue
+            seen.add(Path(entry["path"]).resolve())
+            entry["scope"] = "global"
+            files.append(entry)
+
+    always = [f for f in files if f["kind"] == "always"]
+    on_demand = [f for f in files if f["kind"] == "on-demand"]
+
+    always_tokens    = sum(f["tokens"] for f in always)
+    on_demand_tokens = sum(f["tokens"] for f in on_demand)
+
+    return {
+        "project_dir":      str(project_dir),
+        "context_window":   CONTEXT_WINDOW,
+        "always_tokens":    always_tokens,
+        "on_demand_tokens": on_demand_tokens,
+        "total_tokens":     always_tokens + on_demand_tokens,
+        "remaining_tokens": max(0, CONTEXT_WINDOW - always_tokens),
+        "files":            files,
+    }
+
+
+# ── Persistence ──────────────────────────────────────────────────────────────
+
+def init_context_tables(conn):
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS context_snapshots (
+            day              TEXT,
+            project_dir      TEXT,
+            always_tokens    INTEGER,
+            on_demand_tokens INTEGER,
+            file_count       INTEGER,
+            PRIMARY KEY (day, project_dir)
+        );
+        CREATE INDEX IF NOT EXISTS idx_context_day ON context_snapshots(day);
+    """)
+    conn.commit()
+
+
+def save_snapshot(conn, snapshot, day=None):
+    init_context_tables(conn)
+    day = day or date.today().isoformat()
+    conn.execute("""
+        INSERT OR REPLACE INTO context_snapshots
+            (day, project_dir, always_tokens, on_demand_tokens, file_count)
+        VALUES (?, ?, ?, ?, ?)
+    """, (
+        day,
+        snapshot["project_dir"],
+        snapshot["always_tokens"],
+        snapshot["on_demand_tokens"],
+        len(snapshot["files"]),
+    ))
+    conn.commit()
+
+
+def known_projects(conn):
+    """Return distinct project cwds Claude Code has been launched in.
+
+    Tries the `turns` table first (populated by scanner.py). Falls back to
+    decoding directory names under ~/.claude/projects/, which Claude Code
+    creates per-cwd by replacing '/' with '-'.
+    """
+    try:
+        rows = conn.execute("""
+            SELECT cwd, COUNT(*) as turns
+            FROM turns
+            WHERE cwd IS NOT NULL AND cwd != ''
+            GROUP BY cwd
+            ORDER BY turns DESC
+        """).fetchall()
+        if rows:
+            return [r[0] for r in rows]
+    except sqlite3.OperationalError:
+        pass
+
+    projects_dir = GLOBAL_CLAUDE_DIR / "projects"
+    if not projects_dir.exists():
+        return []
+    found = []
+    for d in projects_dir.iterdir():
+        if not d.is_dir():
+            continue
+        candidate = "/" + d.name.lstrip("-").replace("-", "/")
+        p = Path(candidate)
+        # Skip root and trivial paths — naive '-' → '/' decoding is ambiguous
+        # for directory names that contain hyphens. Require ≥3 path components.
+        if p.exists() and len(p.parts) >= 4:
+            found.append(candidate)
+    return sorted(set(found))
+
+
+def snapshot_all_known(conn, day=None):
+    """Snapshot every project Claude Code has been run in. Returns count."""
+    n = 0
+    for cwd in known_projects(conn):
+        if not Path(cwd).exists():
+            continue
+        snap = scan_project(cwd)
+        save_snapshot(conn, snap, day=day)
+        n += 1
+    return n
+
+
+def get_trend(conn, project_dir=None, days=90):
+    """Return [(day, always_tokens, on_demand_tokens), ...] for the trend chart."""
+    init_context_tables(conn)
+    if project_dir:
+        rows = conn.execute("""
+            SELECT day,
+                   SUM(always_tokens),
+                   SUM(on_demand_tokens)
+            FROM context_snapshots
+            WHERE project_dir = ?
+              AND day >= date('now', ?)
+            GROUP BY day
+            ORDER BY day
+        """, (project_dir, f'-{days} days')).fetchall()
+    else:
+        rows = conn.execute("""
+            SELECT day,
+                   AVG(always_tokens),
+                   AVG(on_demand_tokens)
+            FROM context_snapshots
+            WHERE day >= date('now', ?)
+            GROUP BY day
+            ORDER BY day
+        """, (f'-{days} days',)).fetchall()
+    return [
+        {"day": r[0], "always": int(r[1] or 0), "on_demand": int(r[2] or 0)}
+        for r in rows
+    ]
+
+
+if __name__ == "__main__":
+    import json, sys
+    target = sys.argv[1] if len(sys.argv) > 1 else os.getcwd()
+    snap = scan_project(target)
+    print(json.dumps({k: v for k, v in snap.items() if k != "files"}, indent=2))
+    print(f"\n{len(snap['files'])} files discovered:")
+    for f in sorted(snap["files"], key=lambda x: -x["tokens"])[:20]:
+        print(f"  {f['kind']:9}  {f['tokens']:>7,} tok  {f['rel']}")

--- a/dashboard.py
+++ b/dashboard.py
@@ -11,6 +11,8 @@ from datetime import datetime
 DB_PATH = Path.home() / ".claude" / "usage.db"
 
 import context_scanner
+import transcript_reader
+import releases_fetcher
 
 
 def get_dashboard_data(db_path=DB_PATH):
@@ -73,6 +75,7 @@ def get_dashboard_data(db_path=DB_PATH):
         except Exception:
             duration_min = 0
         sessions_all.append({
+            "session_id_full": r["session_id"],
             "session_id":    r["session_id"][:8],
             "project":       r["project_name"] or "unknown",
             "last":          (r["last_timestamp"] or "")[:16].replace("T", " "),
@@ -210,6 +213,10 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
       <h2>Top Projects by Tokens</h2>
       <div class="chart-wrap"><canvas id="chart-project"></canvas></div>
     </div>
+    <div class="chart-card wide">
+      <h2 id="releases-title">Latest Releases</h2>
+      <div id="releases-body" class="muted" style="font-size:13px">Loading...</div>
+    </div>
   </div>
   <div class="table-card">
     <div class="section-title">Recent Sessions</div>
@@ -247,6 +254,19 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
       </tr></thead>
       <tbody id="model-cost-body"></tbody>
     </table>
+  </div>
+</div>
+
+<div id="tx-modal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.7);z-index:1000;align-items:center;justify-content:center;padding:20px">
+  <div style="background:var(--card);border:1px solid var(--border);border-radius:10px;max-width:1100px;width:100%;max-height:90vh;display:flex;flex-direction:column">
+    <div style="display:flex;align-items:center;justify-content:space-between;padding:16px 20px;border-bottom:1px solid var(--border)">
+      <div>
+        <div id="tx-title" style="font-size:14px;font-weight:600;color:var(--text)"></div>
+        <div id="tx-sub" class="muted" style="font-size:11px;margin-top:3px"></div>
+      </div>
+      <button onclick="closeTranscript()" style="background:transparent;border:1px solid var(--border);color:var(--muted);border-radius:6px;padding:6px 12px;cursor:pointer;font-size:13px">Close</button>
+    </div>
+    <div id="tx-body" style="overflow-y:auto;padding:16px 20px;font-size:13px;line-height:1.5"></div>
   </div>
 </div>
 
@@ -602,7 +622,7 @@ function renderSessionsTable(sessions) {
     const costCell = isBillable(s.model)
       ? `<td class="cost">${fmtCost(cost)}</td>`
       : `<td class="cost-na">n/a</td>`;
-    return `<tr>
+    return `<tr style="cursor:pointer" onclick="openTranscript('${s.session_id_full}')">
       <td class="muted" style="font-family:monospace">${s.session_id}&hellip;</td>
       <td>${s.project}</td>
       <td class="muted">${s.last}</td>
@@ -632,6 +652,83 @@ function renderModelCostTable(byModel) {
       ${costCell}
     </tr>`;
   }).join('');
+}
+
+// ── Transcript modal ───────────────────────────────────────────────────────
+function escapeHtml(s) {
+  return (s || '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+}
+
+async function openTranscript(sessionId) {
+  const modal = document.getElementById('tx-modal');
+  modal.style.display = 'flex';
+  document.getElementById('tx-title').textContent = 'Loading transcript\u2026';
+  document.getElementById('tx-sub').textContent = sessionId;
+  document.getElementById('tx-body').innerHTML = '<div class="muted">Reading JSONL\u2026</div>';
+  try {
+    const r = await fetch('/api/transcript?session_id=' + encodeURIComponent(sessionId));
+    const d = await r.json();
+    if (d.error) {
+      document.getElementById('tx-body').innerHTML = '<div style="color:#f87171">' + escapeHtml(d.error) + '</div>';
+      return;
+    }
+    document.getElementById('tx-title').textContent = 'Session ' + sessionId.slice(0, 8) + '\u2026 \u00b7 ' + d.turn_count + ' turns';
+    document.getElementById('tx-sub').textContent = (d.project || '') + '  \u00b7  ' + (d.file || '');
+    document.getElementById('tx-body').innerHTML = d.turns.map(t => {
+      const isUser = t.role === 'user';
+      const accent = isUser ? '#4f8ef7' : '#d97757';
+      const tag = isUser ? 'USER' : (t.tool_name ? 'ASSISTANT \u00b7 ' + t.tool_name : 'ASSISTANT');
+      return `
+        <div style="margin-bottom:14px;border-left:3px solid ${accent};padding:8px 12px;background:rgba(255,255,255,0.02);border-radius:0 6px 6px 0">
+          <div class="muted" style="font-size:10px;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:4px">
+            ${tag} \u00b7 ${(t.timestamp || '').slice(0, 19).replace('T', ' ')}${t.model ? ' \u00b7 ' + escapeHtml(t.model) : ''}
+          </div>
+          <pre style="margin:0;white-space:pre-wrap;word-break:break-word;font-family:inherit;color:var(--text);font-size:12px">${escapeHtml(t.text)}</pre>
+        </div>`;
+    }).join('') || '<div class="muted">No turns.</div>';
+  } catch (e) {
+    document.getElementById('tx-body').innerHTML = '<div style="color:#f87171">' + escapeHtml(e.message) + '</div>';
+  }
+}
+
+function closeTranscript() {
+  document.getElementById('tx-modal').style.display = 'none';
+}
+
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape') closeTranscript();
+});
+
+// ── Releases ───────────────────────────────────────────────────────────────
+async function loadReleases() {
+  try {
+    const r = await fetch('/api/releases');
+    const d = await r.json();
+    document.getElementById('releases-title').textContent = 'Latest Releases \u00b7 ' + (d.repo || '');
+    if (d.error && (!d.releases || !d.releases.length)) {
+      document.getElementById('releases-body').innerHTML = '<div style="color:#f87171">' + escapeHtml(d.error) + '</div>';
+      return;
+    }
+    const items = (d.releases || []).slice(0, 8);
+    if (!items.length) {
+      document.getElementById('releases-body').innerHTML = '<div class="muted">No releases.</div>';
+      return;
+    }
+    document.getElementById('releases-body').innerHTML = items.map(rel => {
+      const badge = rel.prerelease ? '<span class="model-tag" style="background:rgba(251,191,36,0.18);color:#fbbf24;margin-left:6px">pre</span>' : '';
+      return `
+        <div style="padding:10px 0;border-bottom:1px solid var(--border)">
+          <div style="display:flex;align-items:baseline;gap:10px;flex-wrap:wrap">
+            <a href="${rel.html_url}" target="_blank" style="color:var(--accent);font-weight:600;text-decoration:none">${escapeHtml(rel.tag || rel.name)}</a>
+            ${badge}
+            <span class="muted" style="font-size:11px">${(rel.published_at || '').slice(0, 10)}</span>
+          </div>
+          ${rel.body ? `<div class="muted" style="font-size:12px;margin-top:4px;max-height:80px;overflow:hidden;white-space:pre-wrap">${escapeHtml(rel.body.slice(0, 400))}${rel.body.length > 400 ? '\u2026' : ''}</div>` : ''}
+        </div>`;
+    }).join('');
+  } catch (e) {
+    document.getElementById('releases-body').innerHTML = '<div style="color:#f87171">' + escapeHtml(e.message) + '</div>';
+  }
 }
 
 // ── Context Window ─────────────────────────────────────────────────────────
@@ -762,6 +859,8 @@ async function loadData() {
 
 loadData();
 loadContext();
+loadReleases();
+setInterval(loadReleases, 6 * 60 * 60 * 1000);
 setInterval(loadData, 30000);
 setInterval(() => loadContext(ctxSelected), 60000);
 </script>
@@ -780,6 +879,40 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
             self.wfile.write(HTML_TEMPLATE.encode("utf-8"))
+
+        elif self.path.startswith("/api/transcript"):
+            from urllib.parse import urlparse, parse_qs
+            qs = parse_qs(urlparse(self.path).query)
+            sid = (qs.get("session_id", [None])[0]) or ""
+            try:
+                conn = sqlite3.connect(DB_PATH)
+                payload = transcript_reader.read_transcript(sid, conn)
+                conn.close()
+            except Exception as e:
+                payload = {"error": str(e)}
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        elif self.path.startswith("/api/releases"):
+            from urllib.parse import urlparse, parse_qs
+            qs = parse_qs(urlparse(self.path).query)
+            repo = (qs.get("repo", [None])[0]) or None
+            try:
+                conn = sqlite3.connect(DB_PATH)
+                payload = releases_fetcher.get_releases(conn, repo=repo)
+                conn.close()
+            except Exception as e:
+                payload = {"error": str(e)}
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
 
         elif self.path.startswith("/api/context"):
             from urllib.parse import urlparse, parse_qs

--- a/dashboard.py
+++ b/dashboard.py
@@ -10,6 +10,8 @@ from datetime import datetime
 
 DB_PATH = Path.home() / ".claude" / "usage.db"
 
+import context_scanner
+
 
 def get_dashboard_data(db_path=DB_PATH):
     if not db_path.exists():
@@ -219,6 +221,23 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
       <tbody id="sessions-body"></tbody>
     </table>
   </div>
+  <div class="table-card">
+    <div class="section-title" style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">
+      <span>Context Window Budget</span>
+      <select id="ctx-project" style="margin-left:auto;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:4px 8px;font-size:12px;max-width:60%"></select>
+    </div>
+    <div id="ctx-meta" class="muted" style="font-size:11px;margin-bottom:12px"></div>
+    <div id="ctx-bar" style="height:14px;border-radius:7px;background:var(--bg);overflow:hidden;display:flex;margin-bottom:12px;border:1px solid var(--border)"></div>
+    <div id="ctx-stats" class="stats-row" style="margin-bottom:16px"></div>
+    <div class="chart-wrap" style="height:180px;margin-bottom:16px"><canvas id="ctx-trend"></canvas></div>
+    <details>
+      <summary style="cursor:pointer;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:8px">Files in context</summary>
+      <table style="margin-top:8px"><thead><tr>
+        <th>Kind</th><th>Scope</th><th>Path</th><th>Tokens</th>
+      </tr></thead><tbody id="ctx-files"></tbody></table>
+    </details>
+  </div>
+
   <div class="table-card">
     <div class="section-title">Cost by Model</div>
     <table>
@@ -615,6 +634,102 @@ function renderModelCostTable(byModel) {
   }).join('');
 }
 
+// ── Context Window ─────────────────────────────────────────────────────────
+let ctxSelected = null;
+
+async function loadContext(project) {
+  try {
+    const url = '/api/context' + (project ? ('?project=' + encodeURIComponent(project)) : '');
+    const r = await fetch(url);
+    const d = await r.json();
+    if (d.error) { console.error(d.error); return; }
+    renderContext(d);
+  } catch(e) { console.error(e); }
+}
+
+function shortPath(p) {
+  if (!p) return '';
+  const parts = p.split('/').filter(Boolean);
+  return parts.length > 2 ? '\u2026/' + parts.slice(-2).join('/') : p;
+}
+
+function renderContext(d) {
+  // Project picker
+  const sel = document.getElementById('ctx-project');
+  if (sel.options.length !== d.projects.length) {
+    sel.innerHTML = d.projects.map(p =>
+      `<option value="${p}">${shortPath(p)}</option>`
+    ).join('');
+    sel.onchange = () => { ctxSelected = sel.value; loadContext(ctxSelected); };
+  }
+  if (d.selected) sel.value = d.selected;
+
+  const snap = d.snapshot;
+  if (!snap) {
+    document.getElementById('ctx-meta').textContent = 'No project selected.';
+    return;
+  }
+
+  const window = d.context_window;
+  const always = snap.always_tokens;
+  const onDemand = snap.on_demand_tokens;
+  const remaining = Math.max(0, window - always);
+  const pctAlways = Math.min(100, (always / window) * 100);
+
+  document.getElementById('ctx-meta').textContent =
+    `${snap.files.length} files \u00b7 ${fmt(window)} token window \u00b7 ${shortPath(snap.project_dir)}`;
+
+  document.getElementById('ctx-bar').innerHTML =
+    `<div style="width:${pctAlways}%;background:var(--accent)" title="Always loaded: ${fmt(always)} tokens"></div>` +
+    `<div style="flex:1;background:var(--card)" title="Free: ${fmt(remaining)} tokens"></div>`;
+
+  document.getElementById('ctx-stats').innerHTML = [
+    { label: 'Always Loaded',  value: fmt(always),    sub: pctAlways.toFixed(1) + '% of window' },
+    { label: 'On-Demand',      value: fmt(onDemand),  sub: 'available, not auto-loaded' },
+    { label: 'Free',           value: fmt(remaining), sub: 'in 200k window', color: '#4ade80' },
+    { label: 'Files',          value: snap.files.length.toString(), sub: 'discovered' },
+  ].map(s => `
+    <div class="stat-card">
+      <div class="label">${s.label}</div>
+      <div class="value" style="${s.color ? 'color:' + s.color : ''}">${s.value}</div>
+      <div class="sub">${s.sub}</div>
+    </div>`).join('');
+
+  // Trend chart
+  const ctx = document.getElementById('ctx-trend').getContext('2d');
+  if (charts.ctx) charts.ctx.destroy();
+  if (d.trend.length) {
+    charts.ctx = new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: d.trend.map(t => t.day),
+        datasets: [
+          { label: 'Always loaded', data: d.trend.map(t => t.always),
+            borderColor: '#d97757', backgroundColor: 'rgba(217,119,87,0.15)', fill: true, tension: 0.25 },
+        ]
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        plugins: { legend: { labels: { color: '#8892a4' } } },
+        scales: {
+          x: { ticks: { color: '#8892a4', maxTicksLimit: 10 }, grid: { color: '#2a2d3a' } },
+          y: { ticks: { color: '#8892a4', callback: v => fmt(v) }, grid: { color: '#2a2d3a' } },
+        }
+      }
+    });
+  }
+
+  // File table — top 50 by tokens
+  const sorted = [...snap.files].sort((a,b) => b.tokens - a.tokens).slice(0, 50);
+  document.getElementById('ctx-files').innerHTML = sorted.map(f => `
+    <tr>
+      <td><span class="model-tag" style="background:${f.kind==='always'?'rgba(217,119,87,0.18)':'rgba(136,146,164,0.15)'};color:${f.kind==='always'?'var(--accent)':'var(--muted)'}">${f.kind}</span></td>
+      <td class="muted">${f.scope || ''}</td>
+      <td class="muted" style="font-family:monospace;font-size:11px">${f.rel}</td>
+      <td class="num">${fmt(f.tokens)}</td>
+    </tr>`).join('');
+}
+
 // ── Data loading ───────────────────────────────────────────────────────────
 async function loadData() {
   try {
@@ -646,7 +761,9 @@ async function loadData() {
 }
 
 loadData();
+loadContext();
 setInterval(loadData, 30000);
+setInterval(() => loadContext(ctxSelected), 60000);
 </script>
 </body>
 </html>
@@ -663,6 +780,35 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
             self.wfile.write(HTML_TEMPLATE.encode("utf-8"))
+
+        elif self.path.startswith("/api/context"):
+            from urllib.parse import urlparse, parse_qs
+            qs = parse_qs(urlparse(self.path).query)
+            project = (qs.get("project", [None])[0]) or None
+            try:
+                conn = sqlite3.connect(DB_PATH)
+                conn.row_factory = sqlite3.Row
+                projects = context_scanner.known_projects(conn)
+                # Default to most-active project if none specified
+                target = project or (projects[0] if projects else None)
+                snapshot = context_scanner.scan_project(target) if target else None
+                trend = context_scanner.get_trend(conn, project_dir=target, days=90)
+                conn.close()
+                payload = {
+                    "projects": projects,
+                    "selected": target,
+                    "snapshot": snapshot,
+                    "trend": trend,
+                    "context_window": context_scanner.CONTEXT_WINDOW,
+                }
+            except Exception as e:
+                payload = {"error": str(e)}
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
 
         elif self.path == "/api/data":
             data = get_dashboard_data()

--- a/releases_fetcher.py
+++ b/releases_fetcher.py
@@ -1,0 +1,107 @@
+"""
+releases_fetcher.py - Fetch GitHub Releases for a configurable repo.
+
+Standalone, stdlib-only. Defaults to anthropics/claude-code so out of the box
+the dashboard shows news for Claude Code itself; users can point it at any
+public repo via the CLAUDE_USAGE_RELEASES_REPO environment variable
+(format: "owner/name") or by passing repo= explicitly.
+
+Results are cached in the existing usage.db SQLite database for 6 hours
+to avoid hitting GitHub's unauthenticated rate limit.
+"""
+
+import json
+import os
+import sqlite3
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone, timedelta
+
+DEFAULT_REPO = "anthropics/claude-code"
+CACHE_TTL_SECONDS = 6 * 3600
+USER_AGENT = "claude-usage-dashboard/1.0"
+
+
+def configured_repo():
+    return os.environ.get("CLAUDE_USAGE_RELEASES_REPO", DEFAULT_REPO).strip() or DEFAULT_REPO
+
+
+def init_releases_table(conn):
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS releases_cache (
+            repo        TEXT PRIMARY KEY,
+            fetched_at  TEXT,
+            payload     TEXT
+        );
+    """)
+    conn.commit()
+
+
+def _fetch_from_github(repo):
+    url = f"https://api.github.com/repos/{repo}/releases?per_page=10"
+    req = urllib.request.Request(url, headers={
+        "User-Agent": USER_AGENT,
+        "Accept": "application/vnd.github+json",
+    })
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+    out = []
+    for r in data:
+        out.append({
+            "tag":          r.get("tag_name"),
+            "name":         r.get("name") or r.get("tag_name"),
+            "published_at": r.get("published_at"),
+            "html_url":     r.get("html_url"),
+            "body":         (r.get("body") or "")[:4000],
+            "prerelease":   bool(r.get("prerelease")),
+            "author":       (r.get("author") or {}).get("login"),
+        })
+    return out
+
+
+def get_releases(conn, repo=None, force=False):
+    """Return list of releases for `repo`, using a 6h SQLite cache."""
+    repo = repo or configured_repo()
+    init_releases_table(conn)
+
+    row = conn.execute(
+        "SELECT fetched_at, payload FROM releases_cache WHERE repo = ?",
+        (repo,),
+    ).fetchone()
+
+    if row and not force:
+        try:
+            fetched = datetime.fromisoformat(row[0])
+            if datetime.now(timezone.utc) - fetched < timedelta(seconds=CACHE_TTL_SECONDS):
+                return {"repo": repo, "cached": True, "releases": json.loads(row[1])}
+        except Exception:
+            pass
+
+    try:
+        releases = _fetch_from_github(repo)
+    except urllib.error.HTTPError as e:
+        # Fall back to stale cache if available
+        if row:
+            return {"repo": repo, "cached": True, "stale": True,
+                    "releases": json.loads(row[1]), "error": f"HTTP {e.code}"}
+        return {"repo": repo, "releases": [], "error": f"HTTP {e.code}"}
+    except Exception as e:
+        if row:
+            return {"repo": repo, "cached": True, "stale": True,
+                    "releases": json.loads(row[1]), "error": str(e)}
+        return {"repo": repo, "releases": [], "error": str(e)}
+
+    conn.execute(
+        "INSERT OR REPLACE INTO releases_cache (repo, fetched_at, payload) VALUES (?, ?, ?)",
+        (repo, datetime.now(timezone.utc).isoformat(), json.dumps(releases)),
+    )
+    conn.commit()
+    return {"repo": repo, "cached": False, "releases": releases}
+
+
+if __name__ == "__main__":
+    conn = sqlite3.connect(os.path.expanduser("~/.claude/usage.db"))
+    out = get_releases(conn, force=True)
+    print(f"Repo: {out['repo']}  Cached: {out.get('cached')}  Count: {len(out['releases'])}")
+    for r in out["releases"][:5]:
+        print(f"  {r['tag']:15} {r['published_at'][:10]}  {r['name']}")

--- a/transcript_reader.py
+++ b/transcript_reader.py
@@ -1,0 +1,144 @@
+"""
+transcript_reader.py - Read full Claude Code conversation transcripts from JSONL.
+
+Standalone, stdlib-only. Given a session_id, locates the JSONL file under
+~/.claude/projects/ that contains it and returns a structured turn-by-turn
+view suitable for rendering.
+"""
+
+import json
+import sqlite3
+from pathlib import Path
+
+PROJECTS_DIR = Path.home() / ".claude" / "projects"
+
+# Hard cap on bytes returned per content block to keep payload sane
+MAX_BLOCK_CHARS = 8000
+
+
+def _flatten_text(content):
+    """Coerce a Claude message content field (str OR list-of-blocks) to plain text."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        t = item.get("type")
+        if t == "text":
+            parts.append(item.get("text", ""))
+        elif t == "tool_use":
+            name = item.get("name", "tool")
+            inp = item.get("input", {})
+            try:
+                preview = json.dumps(inp, indent=2)[:MAX_BLOCK_CHARS]
+            except Exception:
+                preview = str(inp)[:MAX_BLOCK_CHARS]
+            parts.append(f"[tool_use: {name}]\n{preview}")
+        elif t == "tool_result":
+            res = item.get("content", "")
+            if isinstance(res, list):
+                res = _flatten_text(res)
+            parts.append(f"[tool_result]\n{str(res)[:MAX_BLOCK_CHARS]}")
+        elif t == "thinking":
+            parts.append(f"[thinking]\n{item.get('thinking', '')[:MAX_BLOCK_CHARS]}")
+    return "\n\n".join(p for p in parts if p)
+
+
+def find_jsonl_for_session(session_id, conn=None):
+    """Locate the JSONL file containing the given session_id.
+
+    Strategy:
+      1. Glob ~/.claude/projects/**/<session_id>.jsonl (Claude Code names the
+         file after the session_id by default).
+      2. Fall back to scanning processed_files in the DB if available.
+    """
+    if not session_id:
+        return None
+    matches = list(PROJECTS_DIR.glob(f"**/{session_id}.jsonl"))
+    if matches:
+        return matches[0]
+
+    if conn is not None:
+        try:
+            row = conn.execute(
+                "SELECT path FROM processed_files WHERE path LIKE ? LIMIT 1",
+                (f"%{session_id}%",),
+            ).fetchone()
+            if row:
+                return Path(row[0])
+        except sqlite3.OperationalError:
+            pass
+    return None
+
+
+def read_transcript(session_id, conn=None, max_turns=500):
+    """Return a structured transcript for one session.
+
+    Output:
+      { session_id, file, project, turn_count, turns: [
+          { idx, role, timestamp, model, text, tool_name } ...
+      ] }
+    """
+    path = find_jsonl_for_session(session_id, conn)
+    if not path or not path.exists():
+        return {"error": f"No JSONL found for session {session_id}"}
+
+    turns = []
+    project = None
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if rec.get("sessionId") and rec.get("sessionId") != session_id:
+                continue
+            rtype = rec.get("type")
+            if rtype not in ("user", "assistant"):
+                continue
+            if not project:
+                project = rec.get("cwd")
+            msg = rec.get("message", {}) or {}
+            text = _flatten_text(msg.get("content", ""))
+            if not text:
+                continue
+            tool_name = None
+            if isinstance(msg.get("content"), list):
+                for item in msg["content"]:
+                    if isinstance(item, dict) and item.get("type") == "tool_use":
+                        tool_name = item.get("name")
+                        break
+            turns.append({
+                "idx": len(turns),
+                "role": rtype,
+                "timestamp": rec.get("timestamp", ""),
+                "model": msg.get("model"),
+                "text": text,
+                "tool_name": tool_name,
+            })
+            if len(turns) >= max_turns:
+                break
+
+    return {
+        "session_id": session_id,
+        "file": str(path),
+        "project": project,
+        "turn_count": len(turns),
+        "turns": turns,
+    }
+
+
+if __name__ == "__main__":
+    import sys
+    sid = sys.argv[1]
+    out = read_transcript(sid)
+    print(json.dumps({k: v for k, v in out.items() if k != "turns"}, indent=2))
+    print(f"\n{out.get('turn_count', 0)} turns")
+    for t in out.get("turns", [])[:5]:
+        print(f"  [{t['idx']}] {t['role']:9} {t['timestamp'][:19]}  {t['text'][:80]}")


### PR DESCRIPTION
## Summary

Two more standalone features for the dashboard, both generic and dependency-free. Builds on top of #2 but is independent of it — they can be reviewed/merged in either order.

### 1. Session transcript viewer

Click any row in the existing **Recent Sessions** table to open a modal showing the full conversation for that session — every user prompt, every assistant reply (including thinking blocks), and every `tool_use` / `tool_result`. The data is read live from the JSONL file Claude Code wrote at conversation time, so there's no extra storage cost and no information loss vs. just opening the file by hand.

- **`transcript_reader.py`** (new) — given a session_id, locates `~/.claude/projects/**/<session_id>.jsonl`, walks the file, and flattens text/tool_use/tool_result/thinking blocks into renderable turns. Per-block size capped to keep payloads sane.
- **`/api/transcript?session_id=...`** endpoint
- **Modal UI in `dashboard.py`** — dark theme, role-coded left border (blue=user, orange=assistant), tool name in the header, Esc to close.

### 2. GitHub Releases section

A new **Latest Releases** card on the dashboard pulls the most recent 10 releases from a public GitHub repo. Defaults to `anthropics/claude-code` so out of the box every user sees Claude Code release notes; configurable via the `CLAUDE_USAGE_RELEASES_REPO` env var (format: `owner/name`) to point at any repo the user cares about.

- **`releases_fetcher.py`** (new) — stdlib `urllib` only, no auth, 6-hour SQLite cache in a new `releases_cache` table to stay well under GitHub's unauthenticated rate limit. Falls back to stale cache on HTTP errors.
- **`/api/releases`** endpoint (accepts optional `?repo=owner/name`)
- Card renders tag, date, prerelease badge, and a 400-char body excerpt with link out to the release page.

## Why these two

The transcript viewer turns the existing session table from a billing report into a debugging tool — you can immediately see *what* you actually did in that 73¢ session that ran for 4 minutes last Tuesday. The Releases section addresses a real problem for Claude Code power users: there's no in-context way to find out what changed in the most recent CLI release. Both are things every claude-usage user benefits from on day one.

## Notes

- Pure stdlib. No new dependencies.
- All new SQL is `CREATE TABLE IF NOT EXISTS` — safe on existing DBs.
- Releases default points at the official Claude Code repo, but the env var makes the feature reusable for any project.
- This is PR 2 of 2 in the standalone-features series. PR 1 (#2) is the Context Window Budget feature.

## Test plan

- [ ] Pull the branch, run `python cli.py dashboard`.
- [ ] Click any row in Recent Sessions — modal should open with the full conversation, color-coded by role, escape closes it.
- [ ] Sessions with tool calls show tool name in the turn header and `[tool_use: …]` / `[tool_result]` blocks inline.
- [ ] Latest Releases card shows the 10 most recent `anthropics/claude-code` releases.
- [ ] Set `CLAUDE_USAGE_RELEASES_REPO=cli/cli` and restart — card switches repos.
- [ ] Hit `/api/releases` twice within 6h — second response has `"cached": true`.