### PR TITLE
Make server host and port configurable via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ python cli.py stats
 
 # Scan + open browser dashboard at http://localhost:8080
 python cli.py dashboard
+
+# Custom host and port via environment variables
+HOST=0.0.0.0 PORT=9000 python cli.py dashboard
 ```
 
 The scanner is incremental — it tracks each file's path and modification time, so re-running `scan` is fast and only processes new or changed files.
@@ -87,7 +90,7 @@ Claude Code writes one JSONL file per session to `~/.claude/projects/`. Each lin
 
 `scanner.py` parses those files and stores the data in a SQLite database at `~/.claude/usage.db`.
 
-`dashboard.py` serves a single-page dashboard on `localhost:8080` with Chart.js charts (loaded from CDN). It auto-refreshes every 30 seconds and supports model filtering with bookmarkable URLs.
+`dashboard.py` serves a single-page dashboard on `localhost:8080` with Chart.js charts (loaded from CDN). It auto-refreshes every 30 seconds and supports model filtering with bookmarkable URLs. The bind address and port can be overridden with `HOST` and `PORT` environment variables (defaults: `localhost`, `8080`).
 
 ---
 

--- a/cli.py
+++ b/cli.py
@@ -8,6 +8,7 @@ Commands:
   dashboard - Scan + open browser + start dashboard server
 """
 
+import os
 import sys
 import sqlite3
 from pathlib import Path
@@ -255,13 +256,16 @@ def cmd_dashboard():
     print("\nStarting dashboard server...")
     from dashboard import serve
 
+    host = os.environ.get("HOST", "localhost")
+    port = int(os.environ.get("PORT", "8080"))
+
     def open_browser():
         time.sleep(1.0)
-        webbrowser.open("http://localhost:8080")
+        webbrowser.open(f"http://{host}:{port}")
 
     t = threading.Thread(target=open_browser, daemon=True)
     t.start()
-    serve(port=8080)
+    serve(host=host, port=port)
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────

--- a/dashboard.py
+++ b/dashboard.py
@@ -3,6 +3,7 @@ dashboard.py - Local web dashboard served on localhost:8080.
 """
 
 import json
+import os
 import sqlite3
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
@@ -678,9 +679,11 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self.end_headers()
 
 
-def serve(port=8080):
-    server = HTTPServer(("localhost", port), DashboardHandler)
-    print(f"Dashboard running at http://localhost:{port}")
+def serve(host=None, port=None):
+    host = host or os.environ.get("HOST", "localhost")
+    port = port or int(os.environ.get("PORT", "8080"))
+    server = HTTPServer((host, port), DashboardHandler)
+    print(f"Dashboard running at http://{host}:{port}")
     print("Press Ctrl+C to stop.")
     try:
         server.serve_forever()


### PR DESCRIPTION
## Summary

- `HOST` env var controls the bind address (default: `localhost`)
- `PORT` env var controls the port (default: `8080`)
- Works for both `python3 dashboard.py` standalone and `python3 cli.py dashboard`

## Usage

```bash
HOST=0.0.0.0 PORT=9000 python3 dashboard.py
# or
HOST=100.124.119.42 PORT=8765 python3 cli.py dashboard
```

## Test plan

- [x] Run `python3 dashboard.py` — should bind to `localhost:8080` (unchanged behavior)
- [x] Run `HOST=0.0.0.0 PORT=9000 python3 dashboard.py` — should bind to `0.0.0.0:9000`
- [x] Run `HOST=100.x.x.x PORT=8765 python3 cli.py dashboard` — browser URL should match

🤖 Generated with [Claude Code](https://claude.ai/claude-code)