### PR TITLE
Fix API pricing to match current Anthropic rates

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16,12 +16,12 @@ from datetime import datetime, date
 DB_PATH = Path.home() / ".claude" / "usage.db"
 
 PRICING = {
-    "claude-opus-4-6":   {"input": 15.00, "output": 75.00},
-    "claude-opus-4-5":   {"input": 15.00, "output": 75.00},
+    "claude-opus-4-6":   {"input":  5.00, "output": 25.00},
+    "claude-opus-4-5":   {"input":  5.00, "output": 25.00},
     "claude-sonnet-4-6": {"input":  3.00, "output": 15.00},
     "claude-sonnet-4-5": {"input":  3.00, "output": 15.00},
-    "claude-haiku-4-5":  {"input":  0.80, "output":  4.00},
-    "claude-haiku-4-6":  {"input":  0.80, "output":  4.00},
+    "claude-haiku-4-5":  {"input":  1.00, "output":  5.00},
+    "claude-haiku-4-6":  {"input":  1.00, "output":  5.00},
     "default":           {"input":  3.00, "output": 15.00},
 }
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -253,12 +253,12 @@ let charts = {};
 
 // ── Pricing (Anthropic API, April 2026) ────────────────────────────────────
 const PRICING = {
-  'claude-opus-4-6':   { input: 6.15,  output: 30.75, cache_write: 7.69, cache_read: 0.61 },
-  'claude-opus-4-5':   { input: 6.15,  output: 30.75, cache_write: 7.69, cache_read: 0.61 },
-  'claude-sonnet-4-6': { input: 3.69,  output: 18.45, cache_write: 4.61, cache_read: 0.37 },
-  'claude-sonnet-4-5': { input: 3.69,  output: 18.45, cache_write: 4.61, cache_read: 0.37 },
-  'claude-haiku-4-5':  { input: 1.23,  output:  6.15, cache_write: 1.54, cache_read: 0.12 },
-  'claude-haiku-4-6':  { input: 1.23,  output:  6.15, cache_write: 1.54, cache_read: 0.12 },
+  'claude-opus-4-6':   { input:  5.00, output: 25.00, cache_write:  6.25, cache_read: 0.50 },
+  'claude-opus-4-5':   { input:  5.00, output: 25.00, cache_write:  6.25, cache_read: 0.50 },
+  'claude-sonnet-4-6': { input:  3.00, output: 15.00, cache_write:  3.75, cache_read: 0.30 },
+  'claude-sonnet-4-5': { input:  3.00, output: 15.00, cache_write:  3.75, cache_read: 0.30 },
+  'claude-haiku-4-5':  { input:  1.00, output:  5.00, cache_write:  1.25, cache_read: 0.10 },
+  'claude-haiku-4-6':  { input:  1.00, output:  5.00, cache_write:  1.25, cache_read: 0.10 },
 };
 
 function isBillable(model) {

--- a/scanner.py
+++ b/scanner.py
@@ -361,7 +361,7 @@ def scan(projects_dir=PROJECTS_DIR, db_path=DB_PATH, verbose=True):
                     print(f"  Warning: {e}")
 
                 turns = new_turns
-                sessions = aggregate_sessions(list(new_metas.values()) or [], turns)
+                sessions = aggregate_sessions(session_metas, turns)
                 # Update session timestamps from full parse
                 for meta in session_metas:
                     sessions_to_update = [s for s in sessions if s["session_id"] == meta["session_id"]]


### PR DESCRIPTION
## Summary
- **Opus 4.5/4.6**: Corrected from $15/$75 (legacy Opus 4.0/4.1 pricing) to $5/$25 per MTok
- **Haiku 4.5/4.6**: Corrected from $0.80/$4 (Haiku 3.5 pricing) to $1/$5 per MTok
- **Dashboard JS**: Was using entirely different incorrect values; now matches CLI and [Anthropic's published pricing](https://platform.claude.com/docs/en/about-claude/pricing)
- **Scanner bug**: Fixed incremental scan not updating session token totals — `aggregate_sessions` was called with an empty dict instead of parsed session metadata, causing the `sessions` table to fall behind the `turns` table on incremental updates. This led to cost discrepancies between the CLI and dashboard.

Sonnet pricing ($3/$15) was already correct and is unchanged.

After applying, rebuild the database (`rm ~/.claude/usage.db && python cli.py scan`) to correct stale session totals.

Fixes #7

## Test plan
- [x] Run `python cli.py today` and verify cost estimates are reasonable
- [x] Run `python cli.py dashboard` and compare CLI vs dashboard costs for the same sessions — they should now match
- [x] Verify cache pricing ratios: cache read = 0.1x input, cache write = 1.25x input

🤖 Generated with [Claude Code](https://claude.com/claude-code)