### PR TITLE
Add multi-account support with dashboard tabs

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -77,187 +77,215 @@ def require_db():
 # ── Commands ──────────────────────────────────────────────────────────────────
 
 def cmd_scan(projects_dir=None):
-    from scanner import scan
-    scan(projects_dir=Path(projects_dir) if projects_dir else None)
+    from scanner import scan, discover_claude_dirs
+    accounts = discover_claude_dirs()
+    if not accounts:
+        # Fallback to default behavior
+        scan(projects_dir=Path(projects_dir) if projects_dir else None)
+        return
+    for label, acct_projects_dir, db_path in accounts:
+        print(f"\n[{label}] Scanning {acct_projects_dir} ...")
+        # If --projects-dir was given, override only the first account
+        dirs = [Path(projects_dir)] if projects_dir else None
+        scan(projects_dir=dirs[0] if dirs else None, db_path=db_path)
 
 
 def cmd_today():
-    conn = require_db()
-    conn.row_factory = sqlite3.Row
-    today = date.today().isoformat()
-
-    rows = conn.execute("""
-        SELECT
-            COALESCE(model, 'unknown') as model,
-            SUM(input_tokens)          as inp,
-            SUM(output_tokens)         as out,
-            SUM(cache_read_tokens)     as cr,
-            SUM(cache_creation_tokens) as cc,
-            COUNT(*)                   as turns
-        FROM turns
-        WHERE substr(timestamp, 1, 10) = ?
-        GROUP BY model
-        ORDER BY inp + out DESC
-    """, (today,)).fetchall()
-
-    sessions = conn.execute("""
-        SELECT COUNT(DISTINCT session_id) as cnt
-        FROM turns
-        WHERE substr(timestamp, 1, 10) = ?
-    """, (today,)).fetchone()
-
-    print()
-    hr()
-    print(f"  Today's Usage  ({today})")
-    hr()
-
-    if not rows:
-        print("  No usage recorded today.")
-        print()
+    from scanner import discover_claude_dirs
+    accounts = discover_claude_dirs()
+    if not accounts:
+        print("No ~/.claude* directories with projects/ found.")
         return
 
-    total_inp = total_out = total_cr = total_cc = total_turns = 0
-    total_cost = 0.0
+    today = date.today().isoformat()
 
-    for r in rows:
-        cost = calc_cost(r["model"], r["inp"] or 0, r["out"] or 0, r["cr"] or 0, r["cc"] or 0)
-        total_cost += cost
-        total_inp += r["inp"] or 0
-        total_out += r["out"] or 0
-        total_cr  += r["cr"]  or 0
-        total_cc  += r["cc"]  or 0
-        total_turns += r["turns"]
-        print(f"  {r['model']:<30}  turns={r['turns']:<4}  in={fmt(r['inp'] or 0):<8}  out={fmt(r['out'] or 0):<8}  cost={fmt_cost(cost)}")
+    for label, _, db_path in accounts:
+        if not db_path.exists():
+            continue
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
 
-    hr()
-    print(f"  {'TOTAL':<30}  turns={total_turns:<4}  in={fmt(total_inp):<8}  out={fmt(total_out):<8}  cost={fmt_cost(total_cost)}")
-    print()
-    print(f"  Sessions today:   {sessions['cnt']}")
-    print(f"  Cache read:       {fmt(total_cr)}")
-    print(f"  Cache creation:   {fmt(total_cc)}")
-    hr()
-    print()
-    conn.close()
+        rows = conn.execute("""
+            SELECT
+                COALESCE(model, 'unknown') as model,
+                SUM(input_tokens)          as inp,
+                SUM(output_tokens)         as out,
+                SUM(cache_read_tokens)     as cr,
+                SUM(cache_creation_tokens) as cc,
+                COUNT(*)                   as turns
+            FROM turns
+            WHERE substr(timestamp, 1, 10) = ?
+            GROUP BY model
+            ORDER BY inp + out DESC
+        """, (today,)).fetchall()
+
+        sessions = conn.execute("""
+            SELECT COUNT(DISTINCT session_id) as cnt
+            FROM turns
+            WHERE substr(timestamp, 1, 10) = ?
+        """, (today,)).fetchone()
+
+        print()
+        hr()
+        print(f"  [{label}] Today's Usage  ({today})")
+        hr()
+
+        if not rows:
+            print("  No usage recorded today.")
+            print()
+            conn.close()
+            continue
+
+        total_inp = total_out = total_cr = total_cc = total_turns = 0
+        total_cost = 0.0
+
+        for r in rows:
+            cost = calc_cost(r["model"], r["inp"] or 0, r["out"] or 0, r["cr"] or 0, r["cc"] or 0)
+            total_cost += cost
+            total_inp += r["inp"] or 0
+            total_out += r["out"] or 0
+            total_cr  += r["cr"]  or 0
+            total_cc  += r["cc"]  or 0
+            total_turns += r["turns"]
+            print(f"  {r['model']:<30}  turns={r['turns']:<4}  in={fmt(r['inp'] or 0):<8}  out={fmt(r['out'] or 0):<8}  cost={fmt_cost(cost)}")
+
+        hr()
+        print(f"  {'TOTAL':<30}  turns={total_turns:<4}  in={fmt(total_inp):<8}  out={fmt(total_out):<8}  cost={fmt_cost(total_cost)}")
+        print()
+        print(f"  Sessions today:   {sessions['cnt']}")
+        print(f"  Cache read:       {fmt(total_cr)}")
+        print(f"  Cache creation:   {fmt(total_cc)}")
+        hr()
+        print()
+        conn.close()
 
 
 def cmd_stats():
-    conn = require_db()
-    conn.row_factory = sqlite3.Row
+    from scanner import discover_claude_dirs
+    accounts = discover_claude_dirs()
+    if not accounts:
+        print("No ~/.claude* directories with projects/ found.")
+        return
 
-    # Session-level info (count, date range)
-    session_info = conn.execute("""
-        SELECT
-            COUNT(*)                  as sessions,
-            MIN(first_timestamp)      as first,
-            MAX(last_timestamp)       as last
-        FROM sessions
-    """).fetchone()
+    for label, _, db_path in accounts:
+        if not db_path.exists():
+            continue
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
 
-    # All-time totals from turns (more accurate — per-turn model attribution)
-    totals = conn.execute("""
-        SELECT
-            SUM(input_tokens)             as inp,
-            SUM(output_tokens)            as out,
-            SUM(cache_read_tokens)        as cr,
-            SUM(cache_creation_tokens)    as cc,
-            COUNT(*)                      as turns
-        FROM turns
-    """).fetchone()
-
-    # By model from turns (each turn has the actual model used)
-    by_model = conn.execute("""
-        SELECT
-            COALESCE(model, 'unknown') as model,
-            SUM(input_tokens)          as inp,
-            SUM(output_tokens)         as out,
-            SUM(cache_read_tokens)     as cr,
-            SUM(cache_creation_tokens) as cc,
-            COUNT(*)                   as turns,
-            COUNT(DISTINCT session_id) as sessions
-        FROM turns
-        GROUP BY model
-        ORDER BY inp + out DESC
-    """).fetchall()
-
-    # Top 5 projects from turns (join with sessions for project name)
-    top_projects = conn.execute("""
-        SELECT
-            COALESCE(s.project_name, 'unknown') as project_name,
-            SUM(t.input_tokens)  as inp,
-            SUM(t.output_tokens) as out,
-            COUNT(*)             as turns,
-            COUNT(DISTINCT t.session_id) as sessions
-        FROM turns t
-        LEFT JOIN sessions s ON t.session_id = s.session_id
-        GROUP BY s.project_name
-        ORDER BY inp + out DESC
-        LIMIT 5
-    """).fetchall()
-
-    # Daily average (last 30 days)
-    daily_avg = conn.execute("""
-        SELECT
-            AVG(daily_inp) as avg_inp,
-            AVG(daily_out) as avg_out,
-            AVG(daily_cost) as avg_cost
-        FROM (
+        # Session-level info (count, date range)
+        session_info = conn.execute("""
             SELECT
-                substr(timestamp, 1, 10) as day,
-                SUM(input_tokens) as daily_inp,
-                SUM(output_tokens) as daily_out,
-                0.0 as daily_cost
+                COUNT(*)                  as sessions,
+                MIN(first_timestamp)      as first,
+                MAX(last_timestamp)       as last
+            FROM sessions
+        """).fetchone()
+
+        # All-time totals from turns (more accurate — per-turn model attribution)
+        totals = conn.execute("""
+            SELECT
+                SUM(input_tokens)             as inp,
+                SUM(output_tokens)            as out,
+                SUM(cache_read_tokens)        as cr,
+                SUM(cache_creation_tokens)    as cc,
+                COUNT(*)                      as turns
             FROM turns
-            WHERE timestamp >= datetime('now', '-30 days')
-            GROUP BY day
+        """).fetchone()
+
+        # By model from turns (each turn has the actual model used)
+        by_model = conn.execute("""
+            SELECT
+                COALESCE(model, 'unknown') as model,
+                SUM(input_tokens)          as inp,
+                SUM(output_tokens)         as out,
+                SUM(cache_read_tokens)     as cr,
+                SUM(cache_creation_tokens) as cc,
+                COUNT(*)                   as turns,
+                COUNT(DISTINCT session_id) as sessions
+            FROM turns
+            GROUP BY model
+            ORDER BY inp + out DESC
+        """).fetchall()
+
+        # Top 5 projects from turns (join with sessions for project name)
+        top_projects = conn.execute("""
+            SELECT
+                COALESCE(s.project_name, 'unknown') as project_name,
+                SUM(t.input_tokens)  as inp,
+                SUM(t.output_tokens) as out,
+                COUNT(*)             as turns,
+                COUNT(DISTINCT t.session_id) as sessions
+            FROM turns t
+            LEFT JOIN sessions s ON t.session_id = s.session_id
+            GROUP BY s.project_name
+            ORDER BY inp + out DESC
+            LIMIT 5
+        """).fetchall()
+
+        # Daily average (last 30 days)
+        daily_avg = conn.execute("""
+            SELECT
+                AVG(daily_inp) as avg_inp,
+                AVG(daily_out) as avg_out,
+                AVG(daily_cost) as avg_cost
+            FROM (
+                SELECT
+                    substr(timestamp, 1, 10) as day,
+                    SUM(input_tokens) as daily_inp,
+                    SUM(output_tokens) as daily_out,
+                    0.0 as daily_cost
+                FROM turns
+                WHERE timestamp >= datetime('now', '-30 days')
+                GROUP BY day
+            )
+        """).fetchone()
+
+        total_cost = sum(
+            calc_cost(r["model"], r["inp"] or 0, r["out"] or 0, r["cr"] or 0, r["cc"] or 0)
+            for r in by_model
         )
-    """).fetchone()
 
-    # Build total cost across all models
-    total_cost = sum(
-        calc_cost(r["model"], r["inp"] or 0, r["out"] or 0, r["cr"] or 0, r["cc"] or 0)
-        for r in by_model
-    )
+        print()
+        hr("=")
+        print(f"  [{label}] Claude Code Usage - All-Time Statistics")
+        hr("=")
 
-    print()
-    hr("=")
-    print("  Claude Code Usage - All-Time Statistics")
-    hr("=")
-
-    first_date = (session_info["first"] or "")[:10]
-    last_date = (session_info["last"] or "")[:10]
-    print(f"  Period:           {first_date} to {last_date}")
-    print(f"  Total sessions:   {session_info['sessions'] or 0:,}")
-    print(f"  Total turns:      {fmt(totals['turns'] or 0)}")
-    print()
-    print(f"  Input tokens:     {fmt(totals['inp'] or 0):<12}  (raw prompt tokens)")
-    print(f"  Output tokens:    {fmt(totals['out'] or 0):<12}  (generated tokens)")
-    print(f"  Cache read:       {fmt(totals['cr'] or 0):<12}  (90% cheaper than input)")
-    print(f"  Cache creation:   {fmt(totals['cc'] or 0):<12}  (25% premium on input)")
-    print()
-    print(f"  Est. total cost:  ${total_cost:.4f}")
-    hr()
-
-    print("  By Model:")
-    for r in by_model:
-        cost = calc_cost(r["model"], r["inp"] or 0, r["out"] or 0, r["cr"] or 0, r["cc"] or 0)
-        print(f"    {r['model']:<30}  sessions={r['sessions']:<4}  turns={fmt(r['turns'] or 0):<6}  "
-              f"in={fmt(r['inp'] or 0):<8}  out={fmt(r['out'] or 0):<8}  cost={fmt_cost(cost)}")
-
-    hr()
-    print("  Top Projects:")
-    for r in top_projects:
-        print(f"    {(r['project_name'] or 'unknown'):<40}  sessions={r['sessions']:<3}  "
-              f"turns={fmt(r['turns'] or 0):<6}  tokens={fmt((r['inp'] or 0)+(r['out'] or 0))}")
-
-    if daily_avg["avg_inp"]:
+        first_date = (session_info["first"] or "")[:10]
+        last_date = (session_info["last"] or "")[:10]
+        print(f"  Period:           {first_date} to {last_date}")
+        print(f"  Total sessions:   {session_info['sessions'] or 0:,}")
+        print(f"  Total turns:      {fmt(totals['turns'] or 0)}")
+        print()
+        print(f"  Input tokens:     {fmt(totals['inp'] or 0):<12}  (raw prompt tokens)")
+        print(f"  Output tokens:    {fmt(totals['out'] or 0):<12}  (generated tokens)")
+        print(f"  Cache read:       {fmt(totals['cr'] or 0):<12}  (90% cheaper than input)")
+        print(f"  Cache creation:   {fmt(totals['cc'] or 0):<12}  (25% premium on input)")
+        print()
+        print(f"  Est. total cost:  ${total_cost:.4f}")
         hr()
-        print("  Daily Average (last 30 days):")
-        print(f"    Input:   {fmt(int(daily_avg['avg_inp'] or 0))}")
-        print(f"    Output:  {fmt(int(daily_avg['avg_out'] or 0))}")
 
-    hr("=")
-    print()
-    conn.close()
+        print("  By Model:")
+        for r in by_model:
+            cost = calc_cost(r["model"], r["inp"] or 0, r["out"] or 0, r["cr"] or 0, r["cc"] or 0)
+            print(f"    {r['model']:<30}  sessions={r['sessions']:<4}  turns={fmt(r['turns'] or 0):<6}  "
+                  f"in={fmt(r['inp'] or 0):<8}  out={fmt(r['out'] or 0):<8}  cost={fmt_cost(cost)}")
+
+        hr()
+        print("  Top Projects:")
+        for r in top_projects:
+            print(f"    {(r['project_name'] or 'unknown'):<40}  sessions={r['sessions']:<3}  "
+                  f"turns={fmt(r['turns'] or 0):<6}  tokens={fmt((r['inp'] or 0)+(r['out'] or 0))}")
+
+        if daily_avg["avg_inp"]:
+            hr()
+            print("  Daily Average (last 30 days):")
+            print(f"    Input:   {fmt(int(daily_avg['avg_inp'] or 0))}")
+            print(f"    Output:  {fmt(int(daily_avg['avg_out'] or 0))}")
+
+        hr("=")
+        print()
+        conn.close()
 
 
 def cmd_dashboard(projects_dir=None):
@@ -270,9 +298,11 @@ def cmd_dashboard(projects_dir=None):
 
     print("\nStarting dashboard server...")
     from dashboard import serve
+    from scanner import discover_claude_dirs
 
     host = os.environ.get("HOST", "localhost")
     port = int(os.environ.get("PORT", "8080"))
+    accounts = discover_claude_dirs()
 
     def open_browser():
         time.sleep(1.0)
@@ -280,7 +310,7 @@ def cmd_dashboard(projects_dir=None):
 
     t = threading.Thread(target=open_browser, daemon=True)
     t.start()
-    serve(host=host, port=port)
+    serve(host=host, port=port, accounts=accounts)
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────

--- a/dashboard.py
+++ b/dashboard.py
@@ -11,6 +11,23 @@ from datetime import datetime
 
 DB_PATH = Path.home() / ".claude" / "usage.db"
 
+_accounts = None
+
+
+def get_all_accounts_data():
+    """Return data for all discovered accounts."""
+    from scanner import discover_claude_dirs
+    accounts = _accounts or discover_claude_dirs()
+    if not accounts:
+        accounts = [("claude", None, DB_PATH)]
+    result = []
+    for label, _, db_path in accounts:
+        data = get_dashboard_data(db_path)
+        if "error" not in data:
+            data["label"] = label
+            result.append(data)
+    return {"accounts": result}
+
 
 def get_dashboard_data(db_path=DB_PATH):
     if not db_path.exists():
@@ -123,6 +140,11 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
   #rescan-btn:hover { color: var(--text); border-color: var(--accent); }
   #rescan-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
+  #account-tabs { background: var(--card); border-bottom: 1px solid var(--border); padding: 0 24px; display: flex; gap: 0; }
+  .account-tab { padding: 10px 20px; border: none; background: transparent; color: var(--muted); font-size: 13px; font-weight: 500; cursor: pointer; border-bottom: 2px solid transparent; transition: color 0.15s, border-color 0.15s; }
+  .account-tab:hover { color: var(--text); }
+  .account-tab.active { color: var(--accent); border-bottom-color: var(--accent); font-weight: 600; }
+
   #filter-bar { background: var(--card); border-bottom: 1px solid var(--border); padding: 10px 24px; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
   .filter-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); white-space: nowrap; }
   .filter-sep { width: 1px; height: 22px; background: var(--border); flex-shrink: 0; }
@@ -189,6 +211,8 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
   <div class="meta" id="meta">Loading...</div>
   <button id="rescan-btn" onclick="triggerRescan()" title="Rebuild the database from scratch by re-scanning all JSONL files. Use if data looks stale or costs seem wrong.">&#x21bb; Rescan</button>
 </header>
+
+<div id="account-tabs"></div>
 
 <div id="filter-bar">
   <div class="filter-label">Models</div>
@@ -291,6 +315,8 @@ function esc(s) {
 }
 
 // ── State ──────────────────────────────────────────────────────────────────
+let allAccounts = [];
+let selectedAccount = null;
 let rawData = null;
 let selectedModels = new Set();
 let selectedRange = '30d';
@@ -451,9 +477,14 @@ function clearAllModels() {
 }
 
 // ── URL persistence ────────────────────────────────────────────────────────
+function readURLAccount() {
+  return new URLSearchParams(window.location.search).get('account') || null;
+}
+
 function updateURL() {
   const allModels = Array.from(document.querySelectorAll('#model-checkboxes input')).map(cb => cb.value);
   const params = new URLSearchParams();
+  if (selectedAccount && allAccounts.length > 1) params.set('account', selectedAccount);
   if (selectedRange !== '30d') params.set('range', selectedRange);
   if (!isDefaultModelSelection(allModels)) params.set('models', Array.from(selectedModels).join(','));
   const search = params.toString() ? '?' + params.toString() : '';
@@ -839,14 +870,48 @@ async function triggerRescan() {
   btn.textContent = '\u21bb Scanning...';
   try {
     const resp = await fetch('/api/rescan', { method: 'POST' });
-    const d = await resp.json();
-    btn.textContent = '\u21bb Rescan (' + d.new + ' new, ' + d.updated + ' updated)';
+    const results = await resp.json();
+    const totNew = results.reduce((s, r) => s + (r.new || 0), 0);
+    const totUpd = results.reduce((s, r) => s + (r.updated || 0), 0);
+    btn.textContent = '\u21bb Rescan (' + totNew + ' new, ' + totUpd + ' updated)';
     await loadData();
   } catch(e) {
     btn.textContent = '\u21bb Rescan (error)';
     console.error(e);
   }
   setTimeout(() => { btn.textContent = '\u21bb Rescan'; btn.disabled = false; }, 3000);
+}
+
+// ── Account tabs ──────────────────────────────────────────────────────────
+function buildAccountTabs() {
+  const container = document.getElementById('account-tabs');
+  if (allAccounts.length <= 1) {
+    container.style.display = 'none';
+    return;
+  }
+  container.style.display = 'flex';
+  container.innerHTML = '';
+  allAccounts.forEach(a => {
+    const btn = document.createElement('button');
+    btn.className = 'account-tab' + (a.label === selectedAccount ? ' active' : '');
+    btn.dataset.account = a.label;
+    btn.textContent = a.label;
+    btn.addEventListener('click', () => switchAccount(a.label));
+    container.appendChild(btn);
+  });
+}
+
+function switchAccount(label) {
+  selectedAccount = label;
+  const account = allAccounts.find(a => a.label === label);
+  if (!account) return;
+  rawData = account;
+  document.querySelectorAll('.account-tab').forEach(btn =>
+    btn.classList.toggle('active', btn.dataset.account === label)
+  );
+  buildFilterUI(rawData.all_models);
+  updateURL();
+  applyFilter();
 }
 
 // ── Data loading ───────────────────────────────────────────────────────────
@@ -858,19 +923,33 @@ async function loadData() {
       document.body.innerHTML = '<div style="padding:40px;color:#f87171">' + esc(d.error) + '</div>';
       return;
     }
-    document.getElementById('meta').textContent = 'Updated: ' + d.generated_at + ' \u00b7 Auto-refresh in 30s';
 
-    const isFirstLoad = rawData === null;
-    rawData = d;
+    const isFirstLoad = allAccounts.length === 0;
+    allAccounts = d.accounts || [];
+
+    if (!allAccounts.length) {
+      document.body.innerHTML = '<div style="padding:40px;color:#f87171">No accounts found.</div>';
+      return;
+    }
 
     if (isFirstLoad) {
-      // Restore range from URL, mark active button
+      const urlAccount = readURLAccount();
+      selectedAccount = allAccounts.find(a => a.label === urlAccount) ? urlAccount : allAccounts[0].label;
+      buildAccountTabs();
+
       selectedRange = readURLRange();
       document.querySelectorAll('.range-btn').forEach(btn =>
         btn.classList.toggle('active', btn.dataset.range === selectedRange)
       );
-      // Build model filter (reads URL for model selection too)
-      buildFilterUI(d.all_models);
+    }
+
+    const account = allAccounts.find(a => a.label === selectedAccount) || allAccounts[0];
+    rawData = account;
+
+    document.getElementById('meta').textContent = 'Updated: ' + account.generated_at + ' \u00b7 Auto-refresh in 30s';
+
+    if (isFirstLoad) {
+      buildFilterUI(rawData.all_models);
       updateSortIcons();
       updateModelSortIcons();
       updateProjectSortIcons();
@@ -902,7 +981,7 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self.wfile.write(HTML_TEMPLATE.encode("utf-8"))
 
         elif self.path == "/api/data":
-            data = get_dashboard_data()
+            data = get_all_accounts_data()
             body = json.dumps(data).encode("utf-8")
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
@@ -916,12 +995,15 @@ class DashboardHandler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         if self.path == "/api/rescan":
-            # Full rebuild: delete DB and rescan from scratch
-            if DB_PATH.exists():
-                DB_PATH.unlink()
-            from scanner import scan
-            result = scan(verbose=False)
-            body = json.dumps(result).encode("utf-8")
+            from scanner import scan, discover_claude_dirs
+            accounts = _accounts or discover_claude_dirs()
+            results = []
+            for label, projects_dir, db_path in accounts:
+                if db_path.exists():
+                    db_path.unlink()
+                result = scan(projects_dir=projects_dir, db_path=db_path, verbose=False)
+                results.append({"label": label, **result})
+            body = json.dumps(results).encode("utf-8")
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(body)))
@@ -932,7 +1014,9 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self.end_headers()
 
 
-def serve(host=None, port=None):
+def serve(host=None, port=None, accounts=None):
+    global _accounts
+    _accounts = accounts
     host = host or os.environ.get("HOST", "localhost")
     port = port or int(os.environ.get("PORT", "8080"))
     server = HTTPServer((host, port), DashboardHandler)
@@ -945,4 +1029,5 @@ def serve(host=None, port=None):
 
 
 if __name__ == "__main__":
-    serve()
+    from scanner import discover_claude_dirs
+    serve(accounts=discover_claude_dirs())

--- a/scanner.py
+++ b/scanner.py
@@ -15,6 +15,28 @@ DB_PATH = Path.home() / ".claude" / "usage.db"
 DEFAULT_PROJECTS_DIRS = [PROJECTS_DIR, XCODE_PROJECTS_DIR]
 
 
+def discover_claude_dirs():
+    """Find all ~/.claude* directories that contain a projects/ subfolder.
+    Returns list of (label, projects_dir, db_path) tuples.
+    """
+    home = Path.home()
+    results = []
+    for d in sorted(home.glob(".claude*")):
+        if not d.is_dir():
+            continue
+        projects = d / "projects"
+        if projects.is_dir():
+            name = d.name
+            if name == ".claude":
+                label = "claude"
+            elif name.startswith(".claude-"):
+                label = name[len(".claude-"):]
+            else:
+                label = name.lstrip(".")
+            results.append((label, projects, d / "usage.db"))
+    return results
+
+
 def get_db(db_path=DB_PATH):
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -119,8 +119,13 @@ class TestDashboardHTTP(unittest.TestCase):
             self.assertEqual(resp.status, 200)
             self.assertIn("application/json", resp.headers["Content-Type"])
             data = json.loads(resp.read())
-            # Should have expected keys (or error if no DB)
-            self.assertTrue("all_models" in data or "error" in data)
+            # Multi-account envelope: {accounts: [{label, all_models, ...}, ...]}
+            self.assertIn("accounts", data)
+            self.assertIsInstance(data["accounts"], list)
+            if data["accounts"]:
+                account = data["accounts"][0]
+                self.assertIn("label", account)
+                self.assertTrue("all_models" in account or "error" in account)
 
     def test_api_rescan_returns_json(self):
         url = f"http://127.0.0.1:{self.port}/api/rescan"
@@ -129,9 +134,13 @@ class TestDashboardHTTP(unittest.TestCase):
             self.assertEqual(resp.status, 200)
             self.assertIn("application/json", resp.headers["Content-Type"])
             data = json.loads(resp.read())
-            self.assertIn("new", data)
-            self.assertIn("updated", data)
-            self.assertIn("skipped", data)
+            # Multi-account: returns list of {label, new, updated, skipped, ...}
+            self.assertIsInstance(data, list)
+            if data:
+                self.assertIn("label", data[0])
+                self.assertIn("new", data[0])
+                self.assertIn("updated", data[0])
+                self.assertIn("skipped", data[0])
 
     def test_404_for_unknown_path(self):
         url = f"http://127.0.0.1:{self.port}/nonexistent"


### PR DESCRIPTION
# Summary

- Auto-discover all ~/.claude* directories (e.g. ~/.claude, ~/.claude-perso, ~/.claude-taf) that contain a projects/ subfolder
- Each account gets its own usage.db stored inside its directory
- Dashboard shows a tab bar to switch between accounts — each tab loads that account's models, sessions, and charts
- CLI commands (scan, today, stats) now iterate over all discovered accounts with [label] prefixed output
- Tab bar auto-hides when only one account exists (backward-compatible)
- Account selection persisted in URL (?account=perso) for bookmarkability

# Motivation

- Users with multiple Claude Code configurations (e.g. separate work/personal accounts) currently have no way to view usage across them. This adds first-class
- multi-account support with zero configuration — just name your directories ~/.claude-* and they're picked up automatically.