### PR TITLE
Add Docker Compose deployment fixes and documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.github
+__pycache__
+*.pyc
+.env
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.9-slim
+WORKDIR /app
+COPY cli.py scanner.py dashboard.py ./
+RUN adduser --disabled-password --gecos '' appuser
+USER appuser
+ENTRYPOINT ["python", "cli.py"]
+CMD ["dashboard"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,21 @@
 FROM python:3.9-slim
+
 WORKDIR /app
+
+# Copier les fichiers Python
 COPY cli.py scanner.py dashboard.py ./
-RUN adduser --disabled-password --gecos '' appuser
+
+# Créer un groupe et utilisateur avec UID/GID spécifiques
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -g ${GID} appuser && \
+    useradd -m -u ${UID} -g appuser appuser
+
+# Créer le dossier .claude avec les bons droits
+RUN mkdir -p /home/appuser/.claude && \
+    chown -R appuser:appuser /home/appuser/.claude
+
 USER appuser
+
 ENTRYPOINT ["python", "cli.py"]
 CMD ["dashboard"]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ cd claude-usage
 python3 cli.py dashboard
 ```
 
+### Docker (Compose)
+```
+git clone https://github.com/phuryn/claude-usage
+cd claude-usage
+docker compose up -d --build
+```
+
+Then open: http://localhost:8080
+
+Services:
+- `dashboard`: scans once at startup and serves the UI
+- `scanner`: runs `python cli.py scan` every 5 minutes
+
+Volume behavior:
+- The compose file mounts `${HOME}/.claude` from the host into the container.
+- On Linux/WSL, `${HOME}` is the Linux/WSL home. This means usage is read from that environment's Claude logs.
+- If you want to read a different host location, change the source side of the bind mount in `docker-compose.yml`.
+
 ---
 
 ## Usage

--- a/cli.py
+++ b/cli.py
@@ -10,6 +10,7 @@ Commands:
 
 import sys
 import sqlite3
+import os
 from pathlib import Path
 from datetime import datetime, date
 
@@ -255,13 +256,19 @@ def cmd_dashboard():
     print("\nStarting dashboard server...")
     from dashboard import serve
 
+    host = os.getenv("DASHBOARD_HOST", "localhost")
+    port = int(os.getenv("DASHBOARD_PORT", "8080"))
+    no_browser = os.getenv("NO_BROWSER", "0") == "1"
+
     def open_browser():
         time.sleep(1.0)
-        webbrowser.open("http://localhost:8080")
+        webbrowser.open(f"http://localhost:{port}")
 
-    t = threading.Thread(target=open_browser, daemon=True)
-    t.start()
-    serve(port=8080)
+    if not no_browser:
+        t = threading.Thread(target=open_browser, daemon=True)
+        t.start()
+
+    serve(host=host, port=port)
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────

--- a/dashboard.py
+++ b/dashboard.py
@@ -678,14 +678,15 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self.end_headers()
 
 
-def serve(port=8080):
-    server = HTTPServer(("localhost", port), DashboardHandler)
-    print(f"Dashboard running at http://localhost:{port}")
-    print("Press Ctrl+C to stop.")
-    try:
-        server.serve_forever()
-    except KeyboardInterrupt:
-        print("\nStopped.")
+def serve(host="localhost", port=8080):
+  server = HTTPServer((host, port), DashboardHandler)
+  display_host = "localhost" if host == "0.0.0.0" else host
+  print(f"Dashboard running at http://{display_host}:{port}")
+  print("Press Ctrl+C to stop.")
+  try:
+    server.serve_forever()
+  except KeyboardInterrupt:
+    print("\nStopped.")
 
 
 if __name__ == "__main__":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,31 +1,27 @@
 services:
-  # Service dashboard (constant)
   dashboard:
     build: .
     container_name: claude-usage-dashboard
     ports:
       - "8080:8080"
     volumes:
-      - ${HOME}/.claude:/home/appuser/.claude:ro
+      - ${HOME}/.claude:/home/appuser/.claude
     environment:
       - HOME=/home/appuser
-    command: dashboard --host 0.0.0.0 --port 8080
+      - DASHBOARD_HOST=0.0.0.0
+      - DASHBOARD_PORT=8080
+      - NO_BROWSER=1
+    command: ["dashboard"]
     restart: unless-stopped
 
-  # Service scanner (périodique)
   scanner:
     build: .
     container_name: claude-usage-scanner
     volumes:
-      - ${HOME}/.claude:/home/appuser/.claude:ro
+      - ${HOME}/.claude:/home/appuser/.claude
     environment:
       - HOME=/home/appuser
-    command: >
-      sh -c "
-        while true; do
-          python cli.py scan;
-          sleep 300;
-        done
-      "
+    entrypoint: ["sh", "-c"]
+    command:
+      - "while true; do python cli.py scan; echo '--- Scan completed, waiting 5 minutes ---'; sleep 300; done"
     restart: unless-stopped
-    # Pas de ports exposés pour le scanner

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,31 @@
-version: '3.8'
 services:
-  claude-usage:
+  # Service dashboard (constant)
+  dashboard:
     build: .
+    container_name: claude-usage-dashboard
     ports:
       - "8080:8080"
     volumes:
       - ${HOME}/.claude:/home/appuser/.claude:ro
+    environment:
+      - HOME=/home/appuser
     command: dashboard --host 0.0.0.0 --port 8080
+    restart: unless-stopped
+
+  # Service scanner (périodique)
+  scanner:
+    build: .
+    container_name: claude-usage-scanner
+    volumes:
+      - ${HOME}/.claude:/home/appuser/.claude:ro
+    environment:
+      - HOME=/home/appuser
+    command: >
+      sh -c "
+        while true; do
+          python cli.py scan;
+          sleep 300;
+        done
+      "
+    restart: unless-stopped
+    # Pas de ports exposés pour le scanner

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  claude-usage:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - ${HOME}/.claude:/home/appuser/.claude:ro
+    command: dashboard --host 0.0.0.0 --port 8080


### PR DESCRIPTION
## Summary
This PR improves Docker usability and reliability for running the dashboard and scanner services.

### What changed
- Fix Docker Compose runtime behavior for both services.
- Ensure dashboard is reachable from host at `localhost:8080` in containerized runs.
- Keep scanner running on a 5-minute loop without restart errors.
- Add Docker setup documentation to README, including volume behavior notes for Linux/WSL hosts.

### Files updated
- `docker-compose.yml`
- `cli.py`
- `dashboard.py`
- `Dockerfile`
- `README.md`

### Validation
- `docker compose up -d --build` starts both services successfully.
- Dashboard is reachable on port 8080.
- Scanner runs periodic scans without crash loops.
