### PR TITLE
fix: escape external strings in dashboard template literals

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -301,6 +301,7 @@ function fmt(n) {
 }
 function fmtCost(c)    { return '$' + c.toFixed(4); }
 function fmtCostBig(c) { return '$' + c.toFixed(2); }
+function esc(t) { return String(t).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
 
 // ── Chart colors ───────────────────────────────────────────────────────────
 const TOKEN_COLORS = {
@@ -368,9 +369,9 @@ function buildFilterUI(allModels) {
   const container = document.getElementById('model-checkboxes');
   container.innerHTML = sorted.map(m => {
     const checked = selectedModels.has(m);
-    return `<label class="model-cb-label ${checked ? 'checked' : ''}" data-model="${m}">
-      <input type="checkbox" value="${m}" ${checked ? 'checked' : ''} onchange="onModelToggle(this)">
-      ${m}
+    return `<label class="model-cb-label ${checked ? 'checked' : ''}" data-model="${esc(m)}">
+      <input type="checkbox" value="${esc(m)}" ${checked ? 'checked' : ''} onchange="onModelToggle(this)">
+      ${esc(m)}
     </label>`;
   }).join('');
 }
@@ -584,11 +585,11 @@ function renderSessionsTable(sessions) {
       ? `<td class="cost">${fmtCost(cost)}</td>`
       : `<td class="cost-na">n/a</td>`;
     return `<tr>
-      <td class="muted" style="font-family:monospace">${s.session_id}&hellip;</td>
-      <td>${s.project}</td>
-      <td class="muted">${s.last}</td>
+      <td class="muted" style="font-family:monospace">${esc(s.session_id)}&hellip;</td>
+      <td>${esc(s.project)}</td>
+      <td class="muted">${esc(s.last)}</td>
       <td class="muted">${s.duration_min}m</td>
-      <td><span class="model-tag">${s.model}</span></td>
+      <td><span class="model-tag">${esc(s.model)}</span></td>
       <td class="num">${s.turns}</td>
       <td class="num">${fmt(s.input)}</td>
       <td class="num">${fmt(s.output)}</td>
@@ -604,7 +605,7 @@ function renderModelCostTable(byModel) {
       ? `<td class="cost">${fmtCost(cost)}</td>`
       : `<td class="cost-na">n/a</td>`;
     return `<tr>
-      <td><span class="model-tag">${m.model}</span></td>
+      <td><span class="model-tag">${esc(m.model)}</span></td>
       <td class="num">${fmt(m.turns)}</td>
       <td class="num">${fmt(m.input)}</td>
       <td class="num">${fmt(m.output)}</td>


### PR DESCRIPTION
## Summary

- Adds a lightweight `esc()` function to HTML-encode `&`, `<`, `>`, and `"` in values interpolated into `innerHTML` via template literals
- Applied to project names, model names, session IDs, and timestamps in `buildFilterUI`, `renderSessionsTable`, and `renderModelCostTable`
- Numeric values (`fmt()`, `fmtCost()`, `duration_min`, `turns`) are left untouched — safe by construction

## Why

Project names are derived from filesystem paths via JSONL transcripts. While exploitation requires local access (attacker already has code execution), escaping external strings before inserting them into the DOM is standard defensive hygiene.

## Test plan

- [ ] `python3 cli.py scan` completes without errors
- [ ] `python3 cli.py dashboard` serves dashboard on localhost:8080
- [ ] Model filter checkboxes render and toggle correctly
- [ ] Sessions table renders with correct data
- [ ] Model cost table renders with correct data
- [ ] No visual or functional regressions