### PR TITLE
fix: update README pricing to match corrected rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ Costs are calculated using **Anthropic API pricing as of April 2026** ([claude.c
 
 | Model | Input | Output | Cache Write | Cache Read |
 |-------|-------|--------|------------|-----------|
-| claude-opus-4-6 | $6.15/MTok | $30.75/MTok | $7.69/MTok | $0.61/MTok |
-| claude-sonnet-4-6 | $3.69/MTok | $18.45/MTok | $4.61/MTok | $0.37/MTok |
-| claude-haiku-4-5 | $1.23/MTok | $6.15/MTok | $1.54/MTok | $0.12/MTok |
+| claude-opus-4-6 | $5.00/MTok | $25.00/MTok | $6.25/MTok | $0.50/MTok |
+| claude-sonnet-4-6 | $3.00/MTok | $15.00/MTok | $3.75/MTok | $0.30/MTok |
+| claude-haiku-4-5 | $1.00/MTok | $5.00/MTok | $1.25/MTok | $0.10/MTok |
 
 > **Note:** These are API prices. If you use Claude Code via a Max or Pro subscription, your actual cost structure is different (subscription-based, not per-token).
 


### PR DESCRIPTION
## Summary

- Updates README pricing table to match the corrected Anthropic rates from #11
- Opus: $5/$25, Sonnet: $3/$15, Haiku: $1/$5 (cache write 1.25x, cache read 0.1x input)
- All three sources (CLI, dashboard, README) now agree

Completes the fix for #7 — PR #11 fixed CLI and dashboard but left README with stale values.

https://claude.ai/code/session_0116zYYNzEsqDNFfaZTG2stB