### PR TITLE
ci: add test suite and GitHub Actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run tests
+        run: python -m unittest discover -s tests -v

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,124 @@
+"""Tests for cli.py - pricing, formatting, and cost calculation."""
+
+import unittest
+from cli import get_pricing, calc_cost, fmt, fmt_cost, PRICING
+
+
+class TestGetPricing(unittest.TestCase):
+    def test_exact_model_match(self):
+        p = get_pricing("claude-opus-4-6")
+        self.assertEqual(p["input"], 5.00)
+        self.assertEqual(p["output"], 25.00)
+
+    def test_all_known_models_have_pricing(self):
+        for model in ("claude-opus-4-6", "claude-opus-4-5",
+                       "claude-sonnet-4-6", "claude-sonnet-4-5",
+                       "claude-haiku-4-5", "claude-haiku-4-6"):
+            p = get_pricing(model)
+            self.assertGreater(p["input"], 0, f"Missing input price for {model}")
+            self.assertGreater(p["output"], 0, f"Missing output price for {model}")
+
+    def test_prefix_match(self):
+        # A model name with a suffix should still match the base
+        p = get_pricing("claude-sonnet-4-6-20260401")
+        self.assertEqual(p["input"], 3.00)
+        self.assertEqual(p["output"], 15.00)
+
+    def test_unknown_model_returns_default(self):
+        p = get_pricing("some-unknown-model")
+        self.assertEqual(p, PRICING["default"])
+
+    def test_none_model_returns_default(self):
+        p = get_pricing(None)
+        self.assertEqual(p, PRICING["default"])
+
+    def test_empty_string_returns_default(self):
+        p = get_pricing("")
+        self.assertEqual(p, PRICING["default"])
+
+
+class TestCalcCost(unittest.TestCase):
+    def test_basic_cost_calculation(self):
+        # 1M input tokens of Sonnet at $3/MTok = $3.00
+        cost = calc_cost("claude-sonnet-4-6", 1_000_000, 0, 0, 0)
+        self.assertAlmostEqual(cost, 3.00)
+
+    def test_output_tokens(self):
+        # 1M output tokens of Sonnet at $15/MTok = $15.00
+        cost = calc_cost("claude-sonnet-4-6", 0, 1_000_000, 0, 0)
+        self.assertAlmostEqual(cost, 15.00)
+
+    def test_cache_read_discount(self):
+        # Cache read = 10% of input price
+        # 1M cache_read of Opus at $5 * 0.10 = $0.50
+        cost = calc_cost("claude-opus-4-6", 0, 0, 1_000_000, 0)
+        self.assertAlmostEqual(cost, 0.50)
+
+    def test_cache_creation_premium(self):
+        # Cache creation = 125% of input price
+        # 1M cache_creation of Opus at $5 * 1.25 = $6.25
+        cost = calc_cost("claude-opus-4-6", 0, 0, 0, 1_000_000)
+        self.assertAlmostEqual(cost, 6.25)
+
+    def test_combined_cost(self):
+        cost = calc_cost("claude-haiku-4-5",
+                         inp=500_000, out=100_000,
+                         cache_read=200_000, cache_creation=50_000)
+        expected = (
+            500_000 * 1.00 / 1_000_000 +   # input
+            100_000 * 5.00 / 1_000_000 +    # output
+            200_000 * 1.00 * 0.10 / 1_000_000 +  # cache read
+            50_000 * 1.00 * 1.25 / 1_000_000     # cache creation
+        )
+        self.assertAlmostEqual(cost, expected)
+
+    def test_zero_tokens(self):
+        cost = calc_cost("claude-opus-4-6", 0, 0, 0, 0)
+        self.assertEqual(cost, 0.0)
+
+
+class TestFmt(unittest.TestCase):
+    def test_millions(self):
+        self.assertEqual(fmt(1_500_000), "1.50M")
+        self.assertEqual(fmt(1_000_000), "1.00M")
+
+    def test_thousands(self):
+        self.assertEqual(fmt(1_500), "1.5K")
+        self.assertEqual(fmt(1_000), "1.0K")
+
+    def test_small_numbers(self):
+        self.assertEqual(fmt(999), "999")
+        self.assertEqual(fmt(0), "0")
+
+
+class TestFmtCost(unittest.TestCase):
+    def test_formatting(self):
+        self.assertEqual(fmt_cost(3.0), "$3.0000")
+        self.assertEqual(fmt_cost(0.0001), "$0.0001")
+        self.assertEqual(fmt_cost(0), "$0.0000")
+
+
+class TestPricingConsistency(unittest.TestCase):
+    """Ensure CLI pricing matches known Anthropic API rates."""
+
+    def test_opus_pricing(self):
+        for model in ("claude-opus-4-6", "claude-opus-4-5"):
+            p = get_pricing(model)
+            self.assertEqual(p["input"], 5.00, f"{model} input price wrong")
+            self.assertEqual(p["output"], 25.00, f"{model} output price wrong")
+
+    def test_sonnet_pricing(self):
+        for model in ("claude-sonnet-4-6", "claude-sonnet-4-5"):
+            p = get_pricing(model)
+            self.assertEqual(p["input"], 3.00, f"{model} input price wrong")
+            self.assertEqual(p["output"], 15.00, f"{model} output price wrong")
+
+    def test_haiku_pricing(self):
+        for model in ("claude-haiku-4-5", "claude-haiku-4-6"):
+            p = get_pricing(model)
+            self.assertEqual(p["input"], 1.00, f"{model} input price wrong")
+            self.assertEqual(p["output"], 5.00, f"{model} output price wrong")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,148 @@
+"""Tests for dashboard.py - API endpoint and data retrieval."""
+
+import json
+import os
+import sqlite3
+import tempfile
+import threading
+import unittest
+import urllib.request
+from pathlib import Path
+
+from scanner import get_db, init_db, upsert_sessions, insert_turns
+from dashboard import get_dashboard_data, DashboardHandler, HTML_TEMPLATE
+
+try:
+    from http.server import HTTPServer
+except ImportError:
+    HTTPServer = None
+
+
+class TestGetDashboardData(unittest.TestCase):
+    def setUp(self):
+        self.tmpfile = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmpfile.close()
+        self.db_path = Path(self.tmpfile.name)
+        conn = get_db(self.db_path)
+        init_db(conn)
+        # Insert sample data
+        sessions = [{
+            "session_id": "sess-abc123", "project_name": "user/myproject",
+            "first_timestamp": "2026-04-08T09:00:00Z",
+            "last_timestamp": "2026-04-08T10:00:00Z",
+            "git_branch": "main", "model": "claude-sonnet-4-6",
+            "total_input_tokens": 5000, "total_output_tokens": 2000,
+            "total_cache_read": 500, "total_cache_creation": 200,
+            "turn_count": 10,
+        }]
+        upsert_sessions(conn, sessions)
+        turns = [{
+            "session_id": "sess-abc123", "timestamp": "2026-04-08T09:30:00Z",
+            "model": "claude-sonnet-4-6", "input_tokens": 500,
+            "output_tokens": 200, "cache_read_tokens": 50,
+            "cache_creation_tokens": 20, "tool_name": None, "cwd": "/tmp",
+        }]
+        insert_turns(conn, turns)
+        conn.commit()
+        conn.close()
+
+    def tearDown(self):
+        os.unlink(self.db_path)
+
+    def test_returns_valid_structure(self):
+        data = get_dashboard_data(db_path=self.db_path)
+        self.assertIn("all_models", data)
+        self.assertIn("daily_by_model", data)
+        self.assertIn("sessions_all", data)
+        self.assertIn("generated_at", data)
+
+    def test_models_populated(self):
+        data = get_dashboard_data(db_path=self.db_path)
+        self.assertIn("claude-sonnet-4-6", data["all_models"])
+
+    def test_sessions_populated(self):
+        data = get_dashboard_data(db_path=self.db_path)
+        self.assertEqual(len(data["sessions_all"]), 1)
+        session = data["sessions_all"][0]
+        self.assertEqual(session["project"], "user/myproject")
+        self.assertEqual(session["model"], "claude-sonnet-4-6")
+        self.assertEqual(session["input"], 5000)
+
+    def test_daily_by_model_populated(self):
+        data = get_dashboard_data(db_path=self.db_path)
+        self.assertGreater(len(data["daily_by_model"]), 0)
+        day = data["daily_by_model"][0]
+        self.assertIn("day", day)
+        self.assertIn("model", day)
+        self.assertIn("input", day)
+
+    def test_missing_db_returns_error(self):
+        data = get_dashboard_data(db_path=Path("/nonexistent/path/usage.db"))
+        self.assertIn("error", data)
+
+    def test_session_id_truncated(self):
+        data = get_dashboard_data(db_path=self.db_path)
+        session = data["sessions_all"][0]
+        self.assertEqual(len(session["session_id"]), 8)
+
+    def test_session_duration_calculated(self):
+        data = get_dashboard_data(db_path=self.db_path)
+        session = data["sessions_all"][0]
+        # 1 hour = 60 minutes
+        self.assertEqual(session["duration_min"], 60.0)
+
+
+class TestDashboardHTTP(unittest.TestCase):
+    """Integration test: start server and make HTTP requests."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server = HTTPServer(("127.0.0.1", 0), DashboardHandler)
+        cls.port = cls.server.server_address[1]
+        cls.thread = threading.Thread(target=cls.server.serve_forever)
+        cls.thread.daemon = True
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+
+    def test_index_returns_html(self):
+        url = f"http://127.0.0.1:{self.port}/"
+        with urllib.request.urlopen(url) as resp:
+            self.assertEqual(resp.status, 200)
+            self.assertIn("text/html", resp.headers["Content-Type"])
+
+    def test_api_data_returns_json(self):
+        url = f"http://127.0.0.1:{self.port}/api/data"
+        with urllib.request.urlopen(url) as resp:
+            self.assertEqual(resp.status, 200)
+            self.assertIn("application/json", resp.headers["Content-Type"])
+            data = json.loads(resp.read())
+            # Should have expected keys (or error if no DB)
+            self.assertTrue("all_models" in data or "error" in data)
+
+    def test_404_for_unknown_path(self):
+        url = f"http://127.0.0.1:{self.port}/nonexistent"
+        try:
+            urllib.request.urlopen(url)
+            self.fail("Expected 404")
+        except urllib.error.HTTPError as e:
+            self.assertEqual(e.code, 404)
+
+
+class TestHTMLTemplate(unittest.TestCase):
+    def test_template_is_valid_html(self):
+        self.assertIn("<!DOCTYPE html>", HTML_TEMPLATE)
+        self.assertIn("</html>", HTML_TEMPLATE)
+
+    def test_template_has_esc_function(self):
+        """Verify XSS protection is present (PR #10)."""
+        self.assertIn("function esc(", HTML_TEMPLATE)
+
+    def test_template_has_chart_js(self):
+        self.assertIn("chart.js", HTML_TEMPLATE.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,319 @@
+"""Tests for scanner.py - JSONL parsing, DB operations, and scanning."""
+
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from scanner import (
+    get_db, init_db, project_name_from_cwd, parse_jsonl_file,
+    aggregate_sessions, upsert_sessions, insert_turns, scan,
+)
+
+
+class TestProjectNameFromCwd(unittest.TestCase):
+    def test_two_components(self):
+        self.assertEqual(project_name_from_cwd("/home/user/myproject"), "user/myproject")
+
+    def test_deep_path(self):
+        self.assertEqual(project_name_from_cwd("/a/b/c/d"), "c/d")
+
+    def test_single_component(self):
+        self.assertEqual(project_name_from_cwd("/root"), "/root")
+
+    def test_windows_path(self):
+        self.assertEqual(project_name_from_cwd("C:\\Users\\me\\project"), "me/project")
+
+    def test_trailing_slash(self):
+        self.assertEqual(project_name_from_cwd("/home/user/project/"), "user/project")
+
+    def test_empty_string(self):
+        self.assertEqual(project_name_from_cwd(""), "unknown")
+
+    def test_none(self):
+        self.assertEqual(project_name_from_cwd(None), "unknown")
+
+
+def _make_assistant_record(session_id="sess-1", model="claude-sonnet-4-6",
+                           input_tokens=100, output_tokens=50,
+                           cache_read=10, cache_creation=5,
+                           timestamp="2026-04-08T10:00:00Z",
+                           cwd="/home/user/project"):
+    return json.dumps({
+        "type": "assistant",
+        "sessionId": session_id,
+        "timestamp": timestamp,
+        "cwd": cwd,
+        "message": {
+            "model": model,
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cache_read_input_tokens": cache_read,
+                "cache_creation_input_tokens": cache_creation,
+            },
+            "content": [],
+        },
+    })
+
+
+def _make_user_record(session_id="sess-1", timestamp="2026-04-08T09:59:00Z",
+                      cwd="/home/user/project"):
+    return json.dumps({
+        "type": "user",
+        "sessionId": session_id,
+        "timestamp": timestamp,
+        "cwd": cwd,
+    })
+
+
+class TestParseJsonlFile(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def _write_jsonl(self, filename, lines):
+        path = os.path.join(self.tmpdir, filename)
+        with open(path, "w") as f:
+            for line in lines:
+                f.write(line + "\n")
+        return path
+
+    def test_basic_parsing(self):
+        path = self._write_jsonl("test.jsonl", [
+            _make_user_record(),
+            _make_assistant_record(),
+        ])
+        metas, turns = parse_jsonl_file(path)
+        self.assertEqual(len(metas), 1)
+        self.assertEqual(len(turns), 1)
+        self.assertEqual(metas[0]["session_id"], "sess-1")
+        self.assertEqual(turns[0]["input_tokens"], 100)
+        self.assertEqual(turns[0]["output_tokens"], 50)
+
+    def test_skips_zero_token_records(self):
+        path = self._write_jsonl("test.jsonl", [
+            _make_assistant_record(input_tokens=0, output_tokens=0,
+                                   cache_read=0, cache_creation=0),
+        ])
+        _, turns = parse_jsonl_file(path)
+        self.assertEqual(len(turns), 0)
+
+    def test_skips_non_assistant_user_types(self):
+        path = self._write_jsonl("test.jsonl", [
+            json.dumps({"type": "system", "sessionId": "s1"}),
+            _make_assistant_record(session_id="s1"),
+        ])
+        metas, turns = parse_jsonl_file(path)
+        self.assertEqual(len(turns), 1)
+
+    def test_handles_malformed_json(self):
+        path = self._write_jsonl("test.jsonl", [
+            "not valid json",
+            _make_assistant_record(),
+        ])
+        _, turns = parse_jsonl_file(path)
+        self.assertEqual(len(turns), 1)
+
+    def test_handles_empty_file(self):
+        path = self._write_jsonl("test.jsonl", [])
+        metas, turns = parse_jsonl_file(path)
+        self.assertEqual(len(metas), 0)
+        self.assertEqual(len(turns), 0)
+
+    def test_multiple_sessions(self):
+        path = self._write_jsonl("test.jsonl", [
+            _make_assistant_record(session_id="s1"),
+            _make_assistant_record(session_id="s2"),
+        ])
+        metas, turns = parse_jsonl_file(path)
+        self.assertEqual(len(metas), 2)
+        self.assertEqual(len(turns), 2)
+
+    def test_session_timestamps_tracked(self):
+        path = self._write_jsonl("test.jsonl", [
+            _make_user_record(timestamp="2026-04-08T09:00:00Z"),
+            _make_assistant_record(timestamp="2026-04-08T09:05:00Z"),
+            _make_assistant_record(timestamp="2026-04-08T09:10:00Z"),
+        ])
+        metas, _ = parse_jsonl_file(path)
+        self.assertEqual(metas[0]["first_timestamp"], "2026-04-08T09:00:00Z")
+        self.assertEqual(metas[0]["last_timestamp"], "2026-04-08T09:10:00Z")
+
+    def test_tool_name_extracted(self):
+        record = json.dumps({
+            "type": "assistant",
+            "sessionId": "s1",
+            "timestamp": "2026-04-08T10:00:00Z",
+            "cwd": "/tmp",
+            "message": {
+                "model": "claude-sonnet-4-6",
+                "usage": {"input_tokens": 100, "output_tokens": 50,
+                          "cache_read_input_tokens": 0,
+                          "cache_creation_input_tokens": 0},
+                "content": [{"type": "tool_use", "name": "Read"}],
+            },
+        })
+        path = self._write_jsonl("test.jsonl", [record])
+        _, turns = parse_jsonl_file(path)
+        self.assertEqual(turns[0]["tool_name"], "Read")
+
+
+class TestAggregateSessions(unittest.TestCase):
+    def test_aggregation(self):
+        metas = [{"session_id": "s1", "project_name": "test",
+                  "first_timestamp": "t1", "last_timestamp": "t2",
+                  "git_branch": "main", "model": None}]
+        turns = [
+            {"session_id": "s1", "input_tokens": 100, "output_tokens": 50,
+             "cache_read_tokens": 10, "cache_creation_tokens": 5, "model": "claude-sonnet-4-6"},
+            {"session_id": "s1", "input_tokens": 200, "output_tokens": 100,
+             "cache_read_tokens": 20, "cache_creation_tokens": 10, "model": "claude-sonnet-4-6"},
+        ]
+        sessions = aggregate_sessions(metas, turns)
+        self.assertEqual(len(sessions), 1)
+        self.assertEqual(sessions[0]["total_input_tokens"], 300)
+        self.assertEqual(sessions[0]["total_output_tokens"], 150)
+        self.assertEqual(sessions[0]["turn_count"], 2)
+        self.assertEqual(sessions[0]["model"], "claude-sonnet-4-6")
+
+    def test_empty_turns(self):
+        metas = [{"session_id": "s1", "project_name": "test",
+                  "first_timestamp": "t1", "last_timestamp": "t2",
+                  "git_branch": "main", "model": None}]
+        sessions = aggregate_sessions(metas, [])
+        self.assertEqual(len(sessions), 1)
+        self.assertEqual(sessions[0]["total_input_tokens"], 0)
+        self.assertEqual(sessions[0]["turn_count"], 0)
+
+
+class TestDatabaseOperations(unittest.TestCase):
+    def setUp(self):
+        self.tmpfile = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmpfile.close()
+        self.db_path = Path(self.tmpfile.name)
+        self.conn = get_db(self.db_path)
+        init_db(self.conn)
+
+    def tearDown(self):
+        self.conn.close()
+        os.unlink(self.db_path)
+
+    def test_init_db_creates_tables(self):
+        tables = self.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        table_names = {r["name"] for r in tables}
+        self.assertIn("sessions", table_names)
+        self.assertIn("turns", table_names)
+        self.assertIn("processed_files", table_names)
+
+    def test_init_db_is_idempotent(self):
+        # Running init_db twice should not error
+        init_db(self.conn)
+        init_db(self.conn)
+
+    def test_upsert_new_session(self):
+        sessions = [{
+            "session_id": "s1", "project_name": "test",
+            "first_timestamp": "2026-04-08T09:00:00Z",
+            "last_timestamp": "2026-04-08T10:00:00Z",
+            "git_branch": "main", "model": "claude-sonnet-4-6",
+            "total_input_tokens": 1000, "total_output_tokens": 500,
+            "total_cache_read": 100, "total_cache_creation": 50,
+            "turn_count": 5,
+        }]
+        upsert_sessions(self.conn, sessions)
+        row = self.conn.execute("SELECT * FROM sessions WHERE session_id = 's1'").fetchone()
+        self.assertIsNotNone(row)
+        self.assertEqual(row["total_input_tokens"], 1000)
+        self.assertEqual(row["turn_count"], 5)
+
+    def test_upsert_updates_existing_session(self):
+        session = {
+            "session_id": "s1", "project_name": "test",
+            "first_timestamp": "2026-04-08T09:00:00Z",
+            "last_timestamp": "2026-04-08T10:00:00Z",
+            "git_branch": "main", "model": "claude-sonnet-4-6",
+            "total_input_tokens": 1000, "total_output_tokens": 500,
+            "total_cache_read": 100, "total_cache_creation": 50,
+            "turn_count": 5,
+        }
+        upsert_sessions(self.conn, [session])
+        # Add more tokens
+        session2 = {**session, "total_input_tokens": 200, "total_output_tokens": 100,
+                    "total_cache_read": 20, "total_cache_creation": 10, "turn_count": 2}
+        upsert_sessions(self.conn, [session2])
+        row = self.conn.execute("SELECT * FROM sessions WHERE session_id = 's1'").fetchone()
+        self.assertEqual(row["total_input_tokens"], 1200)  # 1000 + 200
+        self.assertEqual(row["turn_count"], 7)  # 5 + 2
+
+    def test_insert_turns(self):
+        turns = [{
+            "session_id": "s1", "timestamp": "2026-04-08T10:00:00Z",
+            "model": "claude-sonnet-4-6", "input_tokens": 100,
+            "output_tokens": 50, "cache_read_tokens": 10,
+            "cache_creation_tokens": 5, "tool_name": "Read", "cwd": "/tmp",
+        }]
+        insert_turns(self.conn, turns)
+        rows = self.conn.execute("SELECT * FROM turns").fetchall()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["model"], "claude-sonnet-4-6")
+
+
+class TestScanIntegration(unittest.TestCase):
+    """Integration test: create fake JSONL files and run scan()."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.projects_dir = Path(self.tmpdir) / "projects"
+        self.projects_dir.mkdir()
+        self.db_path = Path(self.tmpdir) / "usage.db"
+
+    def _write_project_jsonl(self, project_name, session_id, num_turns=3):
+        project_dir = self.projects_dir / project_name
+        project_dir.mkdir(parents=True, exist_ok=True)
+        path = project_dir / f"{session_id}.jsonl"
+        with open(path, "w") as f:
+            f.write(_make_user_record(session_id=session_id) + "\n")
+            for i in range(num_turns):
+                ts = f"2026-04-08T10:{i:02d}:00Z"
+                f.write(_make_assistant_record(
+                    session_id=session_id,
+                    timestamp=ts,
+                    input_tokens=100 * (i + 1),
+                    output_tokens=50 * (i + 1),
+                ) + "\n")
+
+    def test_scan_new_files(self):
+        self._write_project_jsonl("user/myproject", "sess-1", num_turns=3)
+        result = scan(projects_dir=self.projects_dir, db_path=self.db_path, verbose=False)
+        self.assertEqual(result["new"], 1)
+        self.assertEqual(result["turns"], 3)
+        self.assertEqual(result["sessions"], 1)
+
+    def test_scan_is_incremental(self):
+        self._write_project_jsonl("user/myproject", "sess-1")
+        scan(projects_dir=self.projects_dir, db_path=self.db_path, verbose=False)
+        # Second scan should skip
+        result = scan(projects_dir=self.projects_dir, db_path=self.db_path, verbose=False)
+        self.assertEqual(result["skipped"], 1)
+        self.assertEqual(result["new"], 0)
+
+    def test_scan_empty_directory(self):
+        result = scan(projects_dir=self.projects_dir, db_path=self.db_path, verbose=False)
+        self.assertEqual(result["new"], 0)
+        self.assertEqual(result["turns"], 0)
+
+    def test_scan_multiple_files(self):
+        self._write_project_jsonl("user/project-a", "sess-1", num_turns=2)
+        self._write_project_jsonl("user/project-b", "sess-2", num_turns=4)
+        result = scan(projects_dir=self.projects_dir, db_path=self.db_path, verbose=False)
+        self.assertEqual(result["new"], 2)
+        self.assertEqual(result["turns"], 6)
+        self.assertEqual(result["sessions"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds 58 tests covering all three modules (`cli.py`, `scanner.py`, `dashboard.py`)
- Adds GitHub Actions workflow that runs tests on every PR and push to main
- Tests run on Python 3.9, 3.11, and 3.12
- Zero external dependencies — uses only stdlib `unittest`

### Test coverage

| Module | Tests | What's covered |
|--------|-------|----------------|
| `cli.py` | 19 | Pricing lookup, prefix matching, cost calculation, formatting, pricing consistency |
| `scanner.py` | 27 | JSONL parsing, malformed input, session metadata, DB init/upsert/insert, incremental scan |
| `dashboard.py` | 12 | API data structure, HTTP endpoints (200/404), HTML template integrity, XSS `esc()` presence |

### CI workflow

Runs `python -m unittest discover -s tests -v` on `ubuntu-latest` with Python 3.9/3.11/3.12 matrix for every PR to `main` and every push to `main`.

https://claude.ai/code/session_0116zYYNzEsqDNFfaZTG2stB