### PR TITLE
fix: align CLI and dashboard pricing with substring matching

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -34,6 +34,14 @@ def get_pricing(model):
     for key in PRICING:
         if key != "default" and model.startswith(key):
             return PRICING[key]
+    # Substring fallback: match model family by keyword
+    m = model.lower()
+    if "opus" in m:
+        return PRICING["claude-opus-4-6"]
+    if "sonnet" in m:
+        return PRICING["claude-sonnet-4-6"]
+    if "haiku" in m:
+        return PRICING["claude-haiku-4-5"]
     return PRICING["default"]
 
 def calc_cost(model, inp, out, cache_read, cache_creation):

--- a/dashboard.py
+++ b/dashboard.py
@@ -269,6 +269,8 @@ const PRICING = {
   'claude-haiku-4-6':  { input:  1.00, output:  5.00, cache_write:  1.25, cache_read: 0.10 },
 };
 
+const DEFAULT_PRICING = { input: 3.00, output: 15.00, cache_write: 3.75, cache_read: 0.30 };
+
 function isBillable(model) {
   if (!model) return false;
   const m = model.toLowerCase();
@@ -276,7 +278,7 @@ function isBillable(model) {
 }
 
 function getPricing(model) {
-  if (!model) return null;
+  if (!model) return DEFAULT_PRICING;
   if (PRICING[model]) return PRICING[model];
   for (const key of Object.keys(PRICING)) {
     if (model.startsWith(key)) return PRICING[key];
@@ -285,7 +287,7 @@ function getPricing(model) {
   if (m.includes('opus'))   return PRICING['claude-opus-4-6'];
   if (m.includes('sonnet')) return PRICING['claude-sonnet-4-6'];
   if (m.includes('haiku'))  return PRICING['claude-haiku-4-5'];
-  return null;
+  return DEFAULT_PRICING;
 }
 
 function calcCost(model, inp, out, cacheRead, cacheCreation) {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,31 @@ class TestGetPricing(unittest.TestCase):
         self.assertEqual(p["input"], 3.00)
         self.assertEqual(p["output"], 15.00)
 
+    def test_substring_match_opus(self):
+        p = get_pricing("new-opus-5-model")
+        self.assertEqual(p["input"], 5.00)
+        self.assertEqual(p["output"], 25.00)
+
+    def test_substring_match_sonnet(self):
+        p = get_pricing("custom-sonnet-variant")
+        self.assertEqual(p["input"], 3.00)
+        self.assertEqual(p["output"], 15.00)
+
+    def test_substring_match_haiku(self):
+        p = get_pricing("experimental-haiku-fast")
+        self.assertEqual(p["input"], 1.00)
+        self.assertEqual(p["output"], 5.00)
+
+    def test_substring_match_case_insensitive(self):
+        p = get_pricing("Claude-Opus-Next")
+        self.assertEqual(p["input"], 5.00)
+
+    def test_prefix_takes_precedence_over_substring(self):
+        # Exact prefix match should win over substring fallback
+        p = get_pricing("claude-opus-4-6-preview")
+        self.assertEqual(p["input"], 5.00)
+        self.assertEqual(p["output"], 25.00)
+
     def test_unknown_model_returns_default(self):
         p = get_pricing("some-unknown-model")
         self.assertEqual(p, PRICING["default"])

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -143,6 +143,55 @@ class TestHTMLTemplate(unittest.TestCase):
     def test_template_has_chart_js(self):
         self.assertIn("chart.js", HTML_TEMPLATE.lower())
 
+    def test_template_has_substring_matching(self):
+        """Verify getPricing falls back to substring match for unknown models."""
+        self.assertIn("m.includes('opus')", HTML_TEMPLATE)
+        self.assertIn("m.includes('sonnet')", HTML_TEMPLATE)
+        self.assertIn("m.includes('haiku')", HTML_TEMPLATE)
+
+    def test_template_has_default_pricing(self):
+        """Verify dashboard has DEFAULT_PRICING for unknown non-billable models."""
+        self.assertIn("DEFAULT_PRICING", HTML_TEMPLATE)
+
+
+class TestPricingParity(unittest.TestCase):
+    """Verify CLI and dashboard pricing tables stay in sync."""
+
+    def _extract_js_pricing(self):
+        """Extract pricing values from the dashboard JS PRICING object."""
+        import re
+        prices = {}
+        for match in re.finditer(
+            r"'(claude-[^']+)':\s*\{\s*input:\s*([\d.]+),\s*output:\s*([\d.]+)",
+            HTML_TEMPLATE
+        ):
+            model, inp, out = match.group(1), float(match.group(2)), float(match.group(3))
+            prices[model] = {"input": inp, "output": out}
+        return prices
+
+    def test_all_cli_models_in_dashboard(self):
+        from cli import PRICING as CLI_PRICING
+        js_prices = self._extract_js_pricing()
+        for model in CLI_PRICING:
+            if model == "default":
+                continue
+            self.assertIn(model, js_prices, f"{model} missing from dashboard JS")
+
+    def test_prices_match(self):
+        from cli import PRICING as CLI_PRICING
+        js_prices = self._extract_js_pricing()
+        for model in CLI_PRICING:
+            if model == "default":
+                continue
+            self.assertAlmostEqual(
+                CLI_PRICING[model]["input"], js_prices[model]["input"],
+                msg=f"{model} input price mismatch"
+            )
+            self.assertAlmostEqual(
+                CLI_PRICING[model]["output"], js_prices[model]["output"],
+                msg=f"{model} output price mismatch"
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- CLI `get_pricing()` now falls back to substring matching (`opus`/`sonnet`/`haiku` in model name) before returning default — matching the dashboard's existing `getPricing()` behavior
- Dashboard `getPricing()` now returns `DEFAULT_PRICING` instead of `null` for unknown models — matching the CLI's behavior
- Both paths now follow identical resolution: exact match → prefix match → substring match → default

**Before:** A model like `new-opus-5` would get Opus pricing ($5/$25) in the dashboard but default Sonnet pricing ($3/$15) in the CLI — a 40% discrepancy on output costs.

**After:** Both agree on Opus pricing for any model containing "opus".

## Tests added (9 new, 67 total)

- Substring match for opus, sonnet, haiku
- Case-insensitive substring matching
- Prefix match takes precedence over substring
- Dashboard template has substring matching and DEFAULT_PRICING
- CLI ↔ dashboard pricing parity (all models, input + output prices)

https://claude.ai/code/session_0116zYYNzEsqDNFfaZTG2stB