### PR TITLE
fix: non-Anthropic models should cost $0

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -23,16 +23,15 @@ PRICING = {
     "claude-sonnet-4-5": {"input":  3.00, "output": 15.00},
     "claude-haiku-4-5":  {"input":  1.00, "output":  5.00},
     "claude-haiku-4-6":  {"input":  1.00, "output":  5.00},
-    "default":           {"input":  3.00, "output": 15.00},
 }
 
 def get_pricing(model):
     if not model:
-        return PRICING["default"]
+        return None
     if model in PRICING:
         return PRICING[model]
     for key in PRICING:
-        if key != "default" and model.startswith(key):
+        if model.startswith(key):
             return PRICING[key]
     # Substring fallback: match model family by keyword
     m = model.lower()
@@ -42,10 +41,12 @@ def get_pricing(model):
         return PRICING["claude-sonnet-4-6"]
     if "haiku" in m:
         return PRICING["claude-haiku-4-5"]
-    return PRICING["default"]
+    return None
 
 def calc_cost(model, inp, out, cache_read, cache_creation):
     p = get_pricing(model)
+    if not p:
+        return 0.0
     return (
         inp          * p["input"]  / 1_000_000 +
         out          * p["output"] / 1_000_000 +

--- a/dashboard.py
+++ b/dashboard.py
@@ -269,8 +269,6 @@ const PRICING = {
   'claude-haiku-4-6':  { input:  1.00, output:  5.00, cache_write:  1.25, cache_read: 0.10 },
 };
 
-const DEFAULT_PRICING = { input: 3.00, output: 15.00, cache_write: 3.75, cache_read: 0.30 };
-
 function isBillable(model) {
   if (!model) return false;
   const m = model.toLowerCase();
@@ -278,7 +276,7 @@ function isBillable(model) {
 }
 
 function getPricing(model) {
-  if (!model) return DEFAULT_PRICING;
+  if (!model) return null;
   if (PRICING[model]) return PRICING[model];
   for (const key of Object.keys(PRICING)) {
     if (model.startsWith(key)) return PRICING[key];
@@ -287,7 +285,7 @@ function getPricing(model) {
   if (m.includes('opus'))   return PRICING['claude-opus-4-6'];
   if (m.includes('sonnet')) return PRICING['claude-sonnet-4-6'];
   if (m.includes('haiku'))  return PRICING['claude-haiku-4-5'];
-  return DEFAULT_PRICING;
+  return null;
 }
 
 function calcCost(model, inp, out, cacheRead, cacheCreation) {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,17 +49,16 @@ class TestGetPricing(unittest.TestCase):
         self.assertEqual(p["input"], 5.00)
         self.assertEqual(p["output"], 25.00)
 
-    def test_unknown_model_returns_default(self):
-        p = get_pricing("some-unknown-model")
-        self.assertEqual(p, PRICING["default"])
+    def test_unknown_model_returns_none(self):
+        self.assertIsNone(get_pricing("glm-5.1"))
+        self.assertIsNone(get_pricing("gpt-4o"))
+        self.assertIsNone(get_pricing("some-unknown-model"))
 
-    def test_none_model_returns_default(self):
-        p = get_pricing(None)
-        self.assertEqual(p, PRICING["default"])
+    def test_none_model_returns_none(self):
+        self.assertIsNone(get_pricing(None))
 
-    def test_empty_string_returns_default(self):
-        p = get_pricing("")
-        self.assertEqual(p, PRICING["default"])
+    def test_empty_string_returns_none(self):
+        self.assertIsNone(get_pricing(""))
 
 
 class TestCalcCost(unittest.TestCase):
@@ -99,6 +98,14 @@ class TestCalcCost(unittest.TestCase):
 
     def test_zero_tokens(self):
         cost = calc_cost("claude-opus-4-6", 0, 0, 0, 0)
+        self.assertEqual(cost, 0.0)
+
+    def test_unknown_model_costs_zero(self):
+        cost = calc_cost("glm-5.1", 1_000_000, 500_000, 100_000, 50_000)
+        self.assertEqual(cost, 0.0)
+
+    def test_non_anthropic_model_costs_zero(self):
+        cost = calc_cost("gpt-4o", 1_000_000, 500_000, 0, 0)
         self.assertEqual(cost, 0.0)
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -149,9 +149,9 @@ class TestHTMLTemplate(unittest.TestCase):
         self.assertIn("m.includes('sonnet')", HTML_TEMPLATE)
         self.assertIn("m.includes('haiku')", HTML_TEMPLATE)
 
-    def test_template_has_default_pricing(self):
-        """Verify dashboard has DEFAULT_PRICING for unknown non-billable models."""
-        self.assertIn("DEFAULT_PRICING", HTML_TEMPLATE)
+    def test_unknown_models_return_null(self):
+        """Verify getPricing returns null for non-Anthropic models."""
+        self.assertIn("return null;", HTML_TEMPLATE)
 
 
 class TestPricingParity(unittest.TestCase):
@@ -173,16 +173,12 @@ class TestPricingParity(unittest.TestCase):
         from cli import PRICING as CLI_PRICING
         js_prices = self._extract_js_pricing()
         for model in CLI_PRICING:
-            if model == "default":
-                continue
             self.assertIn(model, js_prices, f"{model} missing from dashboard JS")
 
     def test_prices_match(self):
         from cli import PRICING as CLI_PRICING
         js_prices = self._extract_js_pricing()
         for model in CLI_PRICING:
-            if model == "default":
-                continue
             self.assertAlmostEqual(
                 CLI_PRICING[model]["input"], js_prices[model]["input"],
                 msg=f"{model} input price mismatch"


### PR DESCRIPTION
## Summary

- Unknown models (glm-5.1, gpt-4o, etc.) now return None/null from pricing lookup and $0 from cost calculation
- Removes the "default" pricing entry that silently charged Sonnet rates for non-Anthropic models
- Both CLI and dashboard now agree: exact match → prefix match → substring (opus/sonnet/haiku) → None/$0

## Tests

- `test_unknown_model_returns_none` — verifies glm-5.1, gpt-4o, etc. get None
- `test_unknown_model_costs_zero` / `test_non_anthropic_model_costs_zero` — verifies $0 cost
- `test_unknown_models_return_null` — verifies dashboard JS returns null
- All 69 tests pass

https://claude.ai/code/session_0116zYYNzEsqDNFfaZTG2stB