### PR TITLE
feat: add Xcode support by scanning its Claude projects directory

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -77,10 +77,8 @@ def require_db():
 # ── Commands ──────────────────────────────────────────────────────────────────
 
 def cmd_scan(projects_dir=None):
-    from scanner import scan, PROJECTS_DIR
-    target = Path(projects_dir) if projects_dir else PROJECTS_DIR
-    print(f"Scanning {target} ...")
-    scan(projects_dir=target)
+    from scanner import scan
+    scan(projects_dir=Path(projects_dir) if projects_dir else None)
 
 
 def cmd_today():

--- a/scanner.py
+++ b/scanner.py
@@ -10,7 +10,9 @@ from pathlib import Path
 from datetime import datetime, timezone
 
 PROJECTS_DIR = Path.home() / ".claude" / "projects"
+XCODE_PROJECTS_DIR = Path.home() / "Library" / "Developer" / "Xcode" / "CodingAssistant" / "ClaudeAgentConfig" / "projects"
 DB_PATH = Path.home() / ".claude" / "usage.db"
+DEFAULT_PROJECTS_DIRS = [PROJECTS_DIR, XCODE_PROJECTS_DIR]
 
 
 def get_db(db_path=DB_PATH):
@@ -252,11 +254,24 @@ def insert_turns(conn, turns):
     ])
 
 
-def scan(projects_dir=PROJECTS_DIR, db_path=DB_PATH, verbose=True):
+def scan(projects_dir=None, projects_dirs=None, db_path=DB_PATH, verbose=True):
     conn = get_db(db_path)
     init_db(conn)
 
-    jsonl_files = glob.glob(str(projects_dir / "**" / "*.jsonl"), recursive=True)
+    if projects_dirs:
+        dirs_to_scan = [Path(d) for d in projects_dirs]
+    elif projects_dir:
+        dirs_to_scan = [Path(projects_dir)]
+    else:
+        dirs_to_scan = DEFAULT_PROJECTS_DIRS
+
+    jsonl_files = []
+    for d in dirs_to_scan:
+        if not d.exists():
+            continue
+        if verbose:
+            print(f"Scanning {d} ...")
+        jsonl_files.extend(glob.glob(str(d / "**" / "*.jsonl"), recursive=True))
     jsonl_files.sort()
 
     new_files = 0
@@ -409,10 +424,9 @@ def scan(projects_dir=PROJECTS_DIR, db_path=DB_PATH, verbose=True):
 
 if __name__ == "__main__":
     import sys
-    projects_dir = PROJECTS_DIR
+    projects_dir = None
     for i, arg in enumerate(sys.argv[1:]):
         if arg == "--projects-dir" and i + 1 < len(sys.argv[1:]):
             projects_dir = Path(sys.argv[i + 2])
             break
-    print(f"Scanning {projects_dir} ...")
     scan(projects_dir=projects_dir)


### PR DESCRIPTION
## Summary

- Adds Xcode support: automatically scans `~/Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig/projects/` in addition to `~/.claude/projects/`
- Scanner now supports multiple default directories via `DEFAULT_PROJECTS_DIRS`, skipping any that don't exist
- macOS Xcode users will see their usage data without any extra flags

Based on PR #3 by @zxiiro, applied on top of the merged #1. Original PR had merge conflicts from #1's changes.

Closes #3

https://claude.ai/code/session_0116zYYNzEsqDNFfaZTG2stB