### PR TITLE
fix: eliminate double file read in incremental scan

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -75,13 +75,14 @@ def project_name_from_cwd(cwd):
 
 
 def parse_jsonl_file(filepath):
-    """Parse a JSONL file and yield (session_data, turns) tuples."""
+    """Parse a JSONL file and return (session_metas, turns, line_count)."""
     turns = []
     session_meta = {}  # session_id -> dict
+    line_count = 0
 
     try:
         with open(filepath, encoding="utf-8", errors="replace") as f:
-            for line in f:
+            for line_count, line in enumerate(f, 1):
                 line = line.strip()
                 if not line:
                     continue
@@ -160,7 +161,7 @@ def parse_jsonl_file(filepath):
     except Exception as e:
         print(f"  Warning: error reading {filepath}: {e}")
 
-    return list(session_meta.values()), turns
+    return list(session_meta.values()), turns, line_count
 
 
 def aggregate_sessions(session_metas, turns):
@@ -298,55 +299,72 @@ def scan(projects_dir=None, projects_dirs=None, db_path=DB_PATH, verbose=True):
         is_new = row is None
         if verbose:
             status = "NEW" if is_new else "UPD"
-            print(f"  [{status}] {os.path.relpath(filepath, projects_dir)}")
+            print(f"  [{status}] {filepath}")
 
-        session_metas, turns = parse_jsonl_file(filepath)
+        if is_new:
+            # New file: full parse (single read, returns line count)
+            session_metas, turns, line_count = parse_jsonl_file(filepath)
 
-        if turns or session_metas:
-            sessions = aggregate_sessions(session_metas, turns)
+            if turns or session_metas:
+                sessions = aggregate_sessions(session_metas, turns)
+                upsert_sessions(conn, sessions)
+                insert_turns(conn, turns)
+                for s in sessions:
+                    total_sessions.add(s["session_id"])
+                total_turns += len(turns)
+                new_files += 1
 
-            # For incremental updates: only insert turns not already in DB
-            if not is_new:
-                # Get existing turns count to detect which are new
-                # Simple approach: delete old turns for these sessions and re-insert
-                # More correct: track file line count and only process new lines
-                old_lines = row["lines"] if row else 0
-                # Re-parse only if file grew
-                current_lines = sum(1 for _ in open(filepath, encoding="utf-8", errors="replace"))
+        else:
+            # Updated file: read once, process only new lines
+            old_lines = row["lines"] if row else 0
+            new_turns = []
+            new_session_metas = {}
+            line_count = 0
 
-                if current_lines <= old_lines:
-                    conn.execute("UPDATE processed_files SET mtime = ? WHERE path = ?",
-                                 (mtime, filepath))
-                    conn.commit()
-                    skipped_files += 1
-                    continue
+            try:
+                with open(filepath, encoding="utf-8", errors="replace") as f:
+                    for line_count, line in enumerate(f, 1):
+                        if line_count <= old_lines:
+                            continue
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            record = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
 
-                # Only process the new lines
-                new_turns = []
-                new_metas = {}
-                try:
-                    with open(filepath, encoding="utf-8", errors="replace") as f:
-                        for i, line in enumerate(f):
-                            if i < old_lines:
-                                continue
-                            line = line.strip()
-                            if not line:
-                                continue
-                            try:
-                                record = json.loads(line)
-                            except json.JSONDecodeError:
-                                continue
+                        rtype = record.get("type")
+                        if rtype not in ("assistant", "user"):
+                            continue
 
-                            rtype = record.get("type")
-                            if rtype != "assistant":
-                                continue
+                        session_id = record.get("sessionId")
+                        if not session_id:
+                            continue
 
-                            session_id = record.get("sessionId")
-                            if not session_id:
-                                continue
+                        timestamp = record.get("timestamp", "")
+                        cwd = record.get("cwd", "")
 
+                        # Track session metadata from new lines
+                        if session_id not in new_session_metas:
+                            new_session_metas[session_id] = {
+                                "session_id": session_id,
+                                "project_name": project_name_from_cwd(cwd),
+                                "first_timestamp": timestamp,
+                                "last_timestamp": timestamp,
+                                "git_branch": record.get("gitBranch", ""),
+                                "model": None,
+                            }
+                        else:
+                            meta = new_session_metas[session_id]
+                            if timestamp and (not meta["last_timestamp"] or timestamp > meta["last_timestamp"]):
+                                meta["last_timestamp"] = timestamp
+
+                        if rtype == "assistant":
                             msg = record.get("message", {})
                             usage = msg.get("usage", {})
+                            model = msg.get("model", "")
+
                             input_tokens = usage.get("input_tokens", 0) or 0
                             output_tokens = usage.get("output_tokens", 0) or 0
                             cache_read = usage.get("cache_read_input_tokens", 0) or 0
@@ -361,48 +379,41 @@ def scan(projects_dir=None, projects_dirs=None, db_path=DB_PATH, verbose=True):
                                     tool_name = item.get("name")
                                     break
 
+                            if model:
+                                new_session_metas[session_id]["model"] = model
+
                             new_turns.append({
                                 "session_id": session_id,
-                                "timestamp": record.get("timestamp", ""),
-                                "model": msg.get("model", ""),
+                                "timestamp": timestamp,
+                                "model": model,
                                 "input_tokens": input_tokens,
                                 "output_tokens": output_tokens,
                                 "cache_read_tokens": cache_read,
                                 "cache_creation_tokens": cache_creation,
                                 "tool_name": tool_name,
-                                "cwd": record.get("cwd", ""),
+                                "cwd": cwd,
                             })
-                except Exception as e:
-                    print(f"  Warning: {e}")
+            except Exception as e:
+                print(f"  Warning: {e}")
 
-                turns = new_turns
-                sessions = aggregate_sessions(session_metas, turns)
-                # Update session timestamps from full parse
-                for meta in session_metas:
-                    sessions_to_update = [s for s in sessions if s["session_id"] == meta["session_id"]]
-                    if not sessions_to_update:
-                        # Session exists but no new turns -- still update timestamps
-                        sessions.append({**meta,
-                                         "total_input_tokens": 0,
-                                         "total_output_tokens": 0,
-                                         "total_cache_read": 0,
-                                         "total_cache_creation": 0,
-                                         "turn_count": 0,
-                                         "model": meta.get("model")})
+            if line_count <= old_lines:
+                # File didn't grow (mtime changed but no new content)
+                conn.execute("UPDATE processed_files SET mtime = ? WHERE path = ?",
+                             (mtime, filepath))
+                conn.commit()
+                skipped_files += 1
+                continue
 
-                updated_files += 1
-            else:
-                new_files += 1
+            if new_turns or new_session_metas:
+                sessions = aggregate_sessions(list(new_session_metas.values()), new_turns)
+                upsert_sessions(conn, sessions)
+                insert_turns(conn, new_turns)
+                for s in sessions:
+                    total_sessions.add(s["session_id"])
+                total_turns += len(new_turns)
+            updated_files += 1
 
-            upsert_sessions(conn, sessions)
-            insert_turns(conn, turns)
-
-            for s in sessions:
-                total_sessions.add(s["session_id"])
-            total_turns += len(turns)
-
-        # Record file as processed
-        line_count = sum(1 for _ in open(filepath, encoding="utf-8", errors="replace"))
+        # Record file as processed (line_count already known from the single read)
         conn.execute("""
             INSERT OR REPLACE INTO processed_files (path, mtime, lines)
             VALUES (?, ?, ?)

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -85,19 +85,20 @@ class TestParseJsonlFile(unittest.TestCase):
             _make_user_record(),
             _make_assistant_record(),
         ])
-        metas, turns = parse_jsonl_file(path)
+        metas, turns, line_count = parse_jsonl_file(path)
         self.assertEqual(len(metas), 1)
         self.assertEqual(len(turns), 1)
         self.assertEqual(metas[0]["session_id"], "sess-1")
         self.assertEqual(turns[0]["input_tokens"], 100)
         self.assertEqual(turns[0]["output_tokens"], 50)
+        self.assertEqual(line_count, 2)
 
     def test_skips_zero_token_records(self):
         path = self._write_jsonl("test.jsonl", [
             _make_assistant_record(input_tokens=0, output_tokens=0,
                                    cache_read=0, cache_creation=0),
         ])
-        _, turns = parse_jsonl_file(path)
+        _, turns, _ = parse_jsonl_file(path)
         self.assertEqual(len(turns), 0)
 
     def test_skips_non_assistant_user_types(self):
@@ -105,7 +106,7 @@ class TestParseJsonlFile(unittest.TestCase):
             json.dumps({"type": "system", "sessionId": "s1"}),
             _make_assistant_record(session_id="s1"),
         ])
-        metas, turns = parse_jsonl_file(path)
+        metas, turns, _ = parse_jsonl_file(path)
         self.assertEqual(len(turns), 1)
 
     def test_handles_malformed_json(self):
@@ -113,12 +114,12 @@ class TestParseJsonlFile(unittest.TestCase):
             "not valid json",
             _make_assistant_record(),
         ])
-        _, turns = parse_jsonl_file(path)
+        _, turns, _ = parse_jsonl_file(path)
         self.assertEqual(len(turns), 1)
 
     def test_handles_empty_file(self):
         path = self._write_jsonl("test.jsonl", [])
-        metas, turns = parse_jsonl_file(path)
+        metas, turns, _ = parse_jsonl_file(path)
         self.assertEqual(len(metas), 0)
         self.assertEqual(len(turns), 0)
 
@@ -127,7 +128,7 @@ class TestParseJsonlFile(unittest.TestCase):
             _make_assistant_record(session_id="s1"),
             _make_assistant_record(session_id="s2"),
         ])
-        metas, turns = parse_jsonl_file(path)
+        metas, turns, _ = parse_jsonl_file(path)
         self.assertEqual(len(metas), 2)
         self.assertEqual(len(turns), 2)
 
@@ -137,7 +138,7 @@ class TestParseJsonlFile(unittest.TestCase):
             _make_assistant_record(timestamp="2026-04-08T09:05:00Z"),
             _make_assistant_record(timestamp="2026-04-08T09:10:00Z"),
         ])
-        metas, _ = parse_jsonl_file(path)
+        metas, _, _ = parse_jsonl_file(path)
         self.assertEqual(metas[0]["first_timestamp"], "2026-04-08T09:00:00Z")
         self.assertEqual(metas[0]["last_timestamp"], "2026-04-08T09:10:00Z")
 
@@ -156,7 +157,7 @@ class TestParseJsonlFile(unittest.TestCase):
             },
         })
         path = self._write_jsonl("test.jsonl", [record])
-        _, turns = parse_jsonl_file(path)
+        _, turns, _ = parse_jsonl_file(path)
         self.assertEqual(turns[0]["tool_name"], "Read")
 
 
@@ -313,6 +314,123 @@ class TestScanIntegration(unittest.TestCase):
         self.assertEqual(result["new"], 2)
         self.assertEqual(result["turns"], 6)
         self.assertEqual(result["sessions"], 2)
+
+
+class TestScanIncrementalUpdate(unittest.TestCase):
+    """Test that updating a file only processes new lines (no double reads)."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.projects_dir = Path(self.tmpdir) / "projects" / "user" / "proj"
+        self.projects_dir.mkdir(parents=True)
+        self.db_path = Path(self.tmpdir) / "usage.db"
+        self.filepath = self.projects_dir / "sess-1.jsonl"
+
+    def _write_initial(self):
+        with open(self.filepath, "w") as f:
+            f.write(_make_user_record(session_id="sess-1",
+                                      timestamp="2026-04-08T09:00:00Z") + "\n")
+            f.write(_make_assistant_record(session_id="sess-1",
+                                           timestamp="2026-04-08T09:01:00Z",
+                                           input_tokens=100, output_tokens=50) + "\n")
+
+    def _append_turns(self):
+        # Ensure mtime visibly changes (filesystem resolution can be ~10ms)
+        import time
+        time.sleep(0.05)
+        with open(self.filepath, "a") as f:
+            f.write(_make_assistant_record(session_id="sess-1",
+                                           timestamp="2026-04-08T09:05:00Z",
+                                           input_tokens=200, output_tokens=100) + "\n")
+            f.write(_make_assistant_record(session_id="sess-1",
+                                           timestamp="2026-04-08T09:10:00Z",
+                                           input_tokens=300, output_tokens=150) + "\n")
+
+    def test_no_duplicate_turns_on_update(self):
+        """Growing a file must add only new turns, not re-insert old ones."""
+        self._write_initial()
+        scan(projects_dir=self.projects_dir.parent.parent, db_path=self.db_path, verbose=False)
+
+        self._append_turns()
+        result = scan(projects_dir=self.projects_dir.parent.parent, db_path=self.db_path, verbose=False)
+
+        self.assertEqual(result["updated"], 1)
+        self.assertEqual(result["turns"], 2)  # only the 2 new turns
+
+        conn = sqlite3.connect(self.db_path)
+        total_turns = conn.execute("SELECT COUNT(*) FROM turns").fetchone()[0]
+        conn.close()
+        self.assertEqual(total_turns, 3)  # 1 original + 2 new
+
+    def test_token_counts_accumulate_correctly(self):
+        """Session totals should reflect all turns, not double-count."""
+        self._write_initial()
+        scan(projects_dir=self.projects_dir.parent.parent, db_path=self.db_path, verbose=False)
+
+        self._append_turns()
+        scan(projects_dir=self.projects_dir.parent.parent, db_path=self.db_path, verbose=False)
+
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        session = conn.execute("SELECT * FROM sessions WHERE session_id = 'sess-1'").fetchone()
+        conn.close()
+        # 100 + 200 + 300 = 600
+        self.assertEqual(session["total_input_tokens"], 600)
+        # 50 + 100 + 150 = 300
+        self.assertEqual(session["total_output_tokens"], 300)
+        self.assertEqual(session["turn_count"], 3)
+
+    def test_session_timestamp_updated(self):
+        """Last timestamp should advance after file grows."""
+        self._write_initial()
+        scan(projects_dir=self.projects_dir.parent.parent, db_path=self.db_path, verbose=False)
+
+        self._append_turns()
+        scan(projects_dir=self.projects_dir.parent.parent, db_path=self.db_path, verbose=False)
+
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        session = conn.execute("SELECT * FROM sessions WHERE session_id = 'sess-1'").fetchone()
+        conn.close()
+        self.assertEqual(session["last_timestamp"], "2026-04-08T09:10:00Z")
+
+    def test_mtime_change_without_growth_skipped(self):
+        """If mtime changes but line count doesn't grow, skip the file."""
+        self._write_initial()
+        scan(projects_dir=self.projects_dir.parent.parent, db_path=self.db_path, verbose=False)
+
+        # Touch the file (change mtime) without adding content
+        import time
+        time.sleep(0.05)
+        os.utime(self.filepath, None)
+
+        result = scan(projects_dir=self.projects_dir.parent.parent, db_path=self.db_path, verbose=False)
+        self.assertEqual(result["skipped"], 1)
+        self.assertEqual(result["updated"], 0)
+        self.assertEqual(result["turns"], 0)
+
+
+class TestParseJsonlFileLineCount(unittest.TestCase):
+    """Test that parse_jsonl_file returns correct line count."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def test_line_count_matches_file(self):
+        path = os.path.join(self.tmpdir, "test.jsonl")
+        with open(path, "w") as f:
+            f.write(_make_user_record() + "\n")
+            f.write(_make_assistant_record() + "\n")
+            f.write(_make_assistant_record(timestamp="2026-04-08T10:01:00Z") + "\n")
+        _, _, line_count = parse_jsonl_file(path)
+        self.assertEqual(line_count, 3)
+
+    def test_empty_file_returns_zero(self):
+        path = os.path.join(self.tmpdir, "empty.jsonl")
+        with open(path, "w") as f:
+            pass
+        _, _, line_count = parse_jsonl_file(path)
+        self.assertEqual(line_count, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **Eliminates double file read** in incremental scan path (was reading files 4 times, now 1)
- **New files**: `parse_jsonl_file` now returns `line_count` alongside session metas and turns (1 read)
- **Updated files**: single pass reads only new lines, builds both `new_session_metas` and `new_turns`, tracks line count during that same read
- Incremental path now processes "user" records for session metadata (timestamps, project name)
- Removes dead `new_metas = {}` dict that was never populated

Fixes #6. Based on PR #26 by @andrelsjunior, reworked for current main.

## Tests (75 total, 6 new)

- `test_no_duplicate_turns_on_update` — growing a file adds only new turns
- `test_token_counts_accumulate_correctly` — session totals reflect all turns without double-counting
- `test_session_timestamp_updated` — last_timestamp advances after file grows
- `test_mtime_change_without_growth_skipped` — touched-but-unchanged files are skipped
- `test_line_count_matches_file` / `test_empty_file_returns_zero` — parse_jsonl_file returns correct line count

https://claude.ai/code/session_0116zYYNzEsqDNFfaZTG2stB