### PR TITLE
feat: add rescan button to dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -119,6 +119,9 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
   header { background: var(--card); border-bottom: 1px solid var(--border); padding: 16px 24px; display: flex; align-items: center; justify-content: space-between; }
   header h1 { font-size: 18px; font-weight: 600; color: var(--accent); }
   header .meta { color: var(--muted); font-size: 12px; }
+  #rescan-btn { background: var(--card); border: 1px solid var(--border); color: var(--muted); padding: 4px 12px; border-radius: 6px; cursor: pointer; font-size: 12px; margin-top: 4px; }
+  #rescan-btn:hover { color: var(--text); border-color: var(--accent); }
+  #rescan-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
   #filter-bar { background: var(--card); border-bottom: 1px solid var(--border); padding: 10px 24px; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
   .filter-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); white-space: nowrap; }
@@ -180,6 +183,7 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
 <header>
   <h1>Claude Code Usage Dashboard</h1>
   <div class="meta" id="meta">Loading...</div>
+  <button id="rescan-btn" onclick="triggerRescan()" title="Re-scan JSONL files from disk and rebuild the database. Use after deleting usage.db or if data looks stale.">&#x21bb; Rescan</button>
 </header>
 
 <div id="filter-bar">
@@ -672,6 +676,23 @@ function renderModelCostTable(byModel) {
   }).join('');
 }
 
+// ── Rescan ────────────────────────────────────────────────────────────────
+async function triggerRescan() {
+  const btn = document.getElementById('rescan-btn');
+  btn.disabled = true;
+  btn.textContent = '\u21bb Scanning...';
+  try {
+    const resp = await fetch('/api/rescan', { method: 'POST' });
+    const d = await resp.json();
+    btn.textContent = '\u21bb Rescan (' + d.new + ' new, ' + d.updated + ' updated)';
+    await loadData();
+  } catch(e) {
+    btn.textContent = '\u21bb Rescan (error)';
+    console.error(e);
+  }
+  setTimeout(() => { btn.textContent = '\u21bb Rescan'; btn.disabled = false; }, 3000);
+}
+
 // ── Data loading ───────────────────────────────────────────────────────────
 async function loadData() {
   try {
@@ -731,6 +752,20 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(body)
 
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        if self.path == "/api/rescan":
+            from scanner import scan
+            result = scan(verbose=False)
+            body = json.dumps(result).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
         else:
             self.send_response(404)
             self.end_headers()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -122,6 +122,17 @@ class TestDashboardHTTP(unittest.TestCase):
             # Should have expected keys (or error if no DB)
             self.assertTrue("all_models" in data or "error" in data)
 
+    def test_api_rescan_returns_json(self):
+        url = f"http://127.0.0.1:{self.port}/api/rescan"
+        req = urllib.request.Request(url, method="POST")
+        with urllib.request.urlopen(req) as resp:
+            self.assertEqual(resp.status, 200)
+            self.assertIn("application/json", resp.headers["Content-Type"])
+            data = json.loads(resp.read())
+            self.assertIn("new", data)
+            self.assertIn("updated", data)
+            self.assertIn("skipped", data)
+
     def test_404_for_unknown_path(self):
         url = f"http://127.0.0.1:{self.port}/nonexistent"
         try:


### PR DESCRIPTION
## Summary

- Adds a "↻ Rescan" button in the dashboard header
- Triggers POST `/api/rescan` which calls `scan(verbose=False)` and returns results
- Button shows scan results briefly (e.g. "↻ Rescan (2 new, 1 updated)") then resets
- Tooltip: "Re-scan JSONL files from disk and rebuild the database. Use after deleting usage.db or if data looks stale."
- Dashboard auto-reloads data after scan completes

https://claude.ai/code/session_0116zYYNzEsqDNFfaZTG2stB