### PR TITLE
task-07104b: PR 1 — Claude+Codex dual-provider dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Claude Code Usage Dashboard
+# AI Usage Dashboard
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
 [![claude-code](https://img.shields.io/badge/claude--code-black?style=flat-square)](https://claude.ai/code)

--- a/cli.py
+++ b/cli.py
@@ -1,5 +1,5 @@
 """
-cli.py - Command-line interface for the Claude Code usage dashboard.
+cli.py - Command-line interface for the AI usage dashboard.
 
 Commands:
   scan      - Scan JSONL files and update the database
@@ -76,9 +76,17 @@ def require_db():
 
 # ── Commands ──────────────────────────────────────────────────────────────────
 
-def cmd_scan(projects_dir=None):
-    from scanner import scan
-    scan(projects_dir=Path(projects_dir) if projects_dir else None)
+def cmd_scan(provider=None):
+    from scanner import scan, scan_codex, PROJECTS_DIR
+    if provider == "codex":
+        print(f"Scanning Codex sessions (~/.codex/sessions/) ...")
+        scan_codex()
+    elif provider == "claude" or provider is None:
+        print(f"Scanning {PROJECTS_DIR} ...")
+        scan()
+    else:
+        print(f"Unknown provider: {provider}. Use: claude, codex")
+        sys.exit(1)
 
 
 def cmd_today():
@@ -220,7 +228,7 @@ def cmd_stats():
 
     print()
     hr("=")
-    print("  Claude Code Usage - All-Time Statistics")
+    print("  AI Usage Dashboard - All-Time Statistics")
     hr("=")
 
     first_date = (session_info["first"] or "")[:10]
@@ -260,19 +268,19 @@ def cmd_stats():
     conn.close()
 
 
-def cmd_dashboard(projects_dir=None):
+def cmd_dashboard():
     import webbrowser
     import threading
     import time
 
     print("Running scan first...")
-    cmd_scan(projects_dir=projects_dir)
+    cmd_scan()
 
-    print("\nStarting dashboard server...")
+    print("\nStarting AI Usage Dashboard server...")
     from dashboard import serve
 
     host = os.environ.get("HOST", "localhost")
-    port = int(os.environ.get("PORT", "8080"))
+    port = int(os.environ.get("PORT", "9123"))
 
     def open_browser():
         time.sleep(1.0)
@@ -286,13 +294,15 @@ def cmd_dashboard(projects_dir=None):
 # ── Entry point ───────────────────────────────────────────────────────────────
 
 USAGE = """
-Claude Code Usage Dashboard
+AI Usage Dashboard
 
 Usage:
-  python cli.py scan [--projects-dir PATH]   Scan JSONL files and update database
-  python cli.py today                        Show today's usage summary
-  python cli.py stats                        Show all-time statistics
-  python cli.py dashboard [--projects-dir PATH]  Scan + start dashboard
+  python cli.py scan [--provider claude|codex]
+                       Scan JSONL files and update database
+  python cli.py today  Show today's usage summary
+  python cli.py stats  Show all-time statistics
+  python cli.py dashboard
+                       Scan + start dashboard at http://localhost:9123
 """
 
 COMMANDS = {
@@ -302,22 +312,19 @@ COMMANDS = {
     "dashboard": cmd_dashboard,
 }
 
-def parse_projects_dir(args):
-    """Extract --projects-dir value from argument list."""
-    for i, arg in enumerate(args):
-        if arg == "--projects-dir" and i + 1 < len(args):
-            return args[i + 1]
-    return None
-
 if __name__ == "__main__":
     if len(sys.argv) < 2 or sys.argv[1] not in COMMANDS:
         print(USAGE)
         sys.exit(0)
 
-    command = sys.argv[1]
-    projects_dir = parse_projects_dir(sys.argv[2:])
-
-    if command in ("scan", "dashboard") and projects_dir:
-        COMMANDS[command](projects_dir=projects_dir)
+    cmd = sys.argv[1]
+    if cmd == "scan":
+        provider = None
+        args = sys.argv[2:]
+        if "--provider" in args:
+            idx = args.index("--provider")
+            if idx + 1 < len(args):
+                provider = args[idx + 1]
+        cmd_scan(provider=provider)
     else:
-        COMMANDS[command]()
+        COMMANDS[cmd]()

--- a/dashboard.py
+++ b/dashboard.py
@@ -47,7 +47,7 @@ def get_codex_status(db_path=DB_PATH):
     state_file = Path.home() / ".cc-agents" / "scripts" / "usage-monitor-state.json"
     if state_file.exists():
         try:
-            with open(state_file) as f:
+            with open(state_file, encoding="utf-8", errors="replace") as f:
                 mon = json.load(f)
             # usage-monitor stores codex data under codex_five_hour / codex_seven_day
             mon_ts_str = mon.get("timestamp") or mon.get("ts") or ""
@@ -105,18 +105,22 @@ def get_dashboard_data(db_path=DB_PATH):
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
 
-    # ── All models (for filter UI) ────────────────────────────────────────────
-    model_rows = conn.execute("""
+    turns_cols = {r["name"] for r in conn.execute("PRAGMA table_info(turns)").fetchall()}
+    sessions_cols = {r["name"] for r in conn.execute("PRAGMA table_info(sessions)").fetchall()}
+    turns_provider_pred = "COALESCE(provider, 'claude') = 'claude'" if "provider" in turns_cols else "1=1"
+    sessions_provider_pred = "COALESCE(provider, 'claude') = 'claude'" if "provider" in sessions_cols else "1=1"
+
+    # Claude tab data
+    model_rows = conn.execute(f"""
         SELECT COALESCE(model, 'unknown') as model
         FROM turns
-        WHERE COALESCE(provider, 'claude') = 'claude'
+        WHERE {turns_provider_pred}
         GROUP BY model
         ORDER BY SUM(input_tokens + output_tokens) DESC
     """).fetchall()
     all_models = [r["model"] for r in model_rows]
 
-    # ── Daily per-model, ALL history (client filters by range) ────────────────
-    daily_rows = conn.execute("""
+    daily_rows = conn.execute(f"""
         SELECT
             substr(timestamp, 1, 10)   as day,
             COALESCE(model, 'unknown') as model,
@@ -126,7 +130,7 @@ def get_dashboard_data(db_path=DB_PATH):
             SUM(cache_creation_tokens) as cache_creation,
             COUNT(*)                   as turns
         FROM turns
-        WHERE COALESCE(provider, 'claude') = 'claude'
+        WHERE {turns_provider_pred}
         GROUP BY day, model
         ORDER BY day, model
     """).fetchall()
@@ -141,27 +145,26 @@ def get_dashboard_data(db_path=DB_PATH):
         "turns":          r["turns"] or 0,
     } for r in daily_rows]
 
-    # ── All sessions (client filters by range and model) ──────────────────────
-    session_rows = conn.execute("""
+    session_rows = conn.execute(f"""
         SELECT
             session_id, project_name, first_timestamp, last_timestamp,
             total_input_tokens, total_output_tokens,
             total_cache_read, total_cache_creation, model, turn_count
         FROM sessions
-        WHERE COALESCE(provider, 'claude') = 'claude'
+        WHERE {sessions_provider_pred}
         ORDER BY last_timestamp DESC
     """).fetchall()
 
     sessions_all = []
     for r in session_rows:
         try:
-            t1 = datetime.fromisoformat(r["first_timestamp"].replace("Z", "+00:00"))
-            t2 = datetime.fromisoformat(r["last_timestamp"].replace("Z", "+00:00"))
+            t1 = datetime.fromisoformat((r["first_timestamp"] or "").replace("Z", "+00:00"))
+            t2 = datetime.fromisoformat((r["last_timestamp"] or "").replace("Z", "+00:00"))
             duration_min = round((t2 - t1).total_seconds() / 60, 1)
         except Exception:
             duration_min = 0
         sessions_all.append({
-            "session_id":    r["session_id"][:8],
+            "session_id":    (r["session_id"] or "")[:8],
             "project":       r["project_name"] or "unknown",
             "last":          (r["last_timestamp"] or "")[:16].replace("T", " "),
             "last_date":     (r["last_timestamp"] or "")[:10],
@@ -184,58 +187,73 @@ def get_dashboard_data(db_path=DB_PATH):
     if db_path.exists():
         conn2 = sqlite3.connect(db_path)
         conn2.row_factory = sqlite3.Row
+        turns_cols2 = {r["name"] for r in conn2.execute("PRAGMA table_info(turns)").fetchall()}
+        sessions_cols2 = {r["name"] for r in conn2.execute("PRAGMA table_info(sessions)").fetchall()}
+        has_turns_provider = "provider" in turns_cols2
+        has_sessions_provider = "provider" in sessions_cols2
 
         # Codex daily
-        cdrows = conn2.execute("""
-            SELECT substr(timestamp,1,10) as day,
-                   COALESCE(model,'gpt-5') as model,
-                   SUM(input_tokens) as input, SUM(output_tokens) as output,
-                   SUM(cache_read_tokens) as cache_read, COUNT(*) as turns
-            FROM turns WHERE provider='codex'
-            GROUP BY day, model ORDER BY day, model
-        """).fetchall()
-        codex_daily_rows = [{
-            "day": r["day"], "model": r["model"],
-            "input": r["input"] or 0, "output": r["output"] or 0,
-            "cache_read": r["cache_read"] or 0, "turns": r["turns"] or 0,
-        } for r in cdrows]
+        if has_turns_provider:
+            cdrows = conn2.execute("""
+                SELECT substr(timestamp,1,10) as day,
+                       COALESCE(model,'gpt-5') as model,
+                       SUM(input_tokens) as input, SUM(output_tokens) as output,
+                       SUM(cache_read_tokens) as cache_read, COUNT(*) as turns
+                FROM turns WHERE provider='codex'
+                GROUP BY day, model ORDER BY day, model
+            """).fetchall()
+            codex_daily_rows = [{
+                "day": r["day"], "model": r["model"],
+                "input": r["input"] or 0, "output": r["output"] or 0,
+                "cache_read": r["cache_read"] or 0, "turns": r["turns"] or 0,
+            } for r in cdrows]
 
         # Codex sessions
-        csrows = conn2.execute("""
-            SELECT session_id, project_name, first_timestamp, last_timestamp,
-                   total_input_tokens, total_output_tokens,
-                   total_cache_read, model, turn_count
-            FROM sessions WHERE provider='codex'
-            ORDER BY last_timestamp DESC
-        """).fetchall()
-        for r in csrows:
-            try:
-                t1 = datetime.fromisoformat((r["first_timestamp"] or "").replace("Z","+00:00"))
-                t2 = datetime.fromisoformat((r["last_timestamp"] or "").replace("Z","+00:00"))
-                dur = round((t2-t1).total_seconds()/60, 1)
-            except Exception:
-                dur = 0
-            codex_sessions_all.append({
-                "session_id": (r["session_id"] or "")[:8],
-                "project": r["project_name"] or "unknown",
-                "last": (r["last_timestamp"] or "")[:16].replace("T"," "),
-                "last_date": (r["last_timestamp"] or "")[:10],
-                "duration_min": dur,
-                "model": r["model"] or "gpt-5",
-                "turns": r["turn_count"] or 0,
-                "input": r["total_input_tokens"] or 0,
-                "output": r["total_output_tokens"] or 0,
-                "cache_read": r["total_cache_read"] or 0,
-            })
+        if has_sessions_provider:
+            csrows = conn2.execute("""
+                SELECT session_id, project_name, first_timestamp, last_timestamp,
+                       total_input_tokens, total_output_tokens,
+                       total_cache_read, model, turn_count
+                FROM sessions WHERE provider='codex'
+                ORDER BY last_timestamp DESC
+            """).fetchall()
+            for r in csrows:
+                try:
+                    t1 = datetime.fromisoformat((r["first_timestamp"] or "").replace("Z", "+00:00"))
+                    t2 = datetime.fromisoformat((r["last_timestamp"] or "").replace("Z", "+00:00"))
+                    dur = round((t2 - t1).total_seconds() / 60, 1)
+                except Exception:
+                    dur = 0
+                codex_sessions_all.append({
+                    "session_id": (r["session_id"] or "")[:8],
+                    "project": r["project_name"] or "unknown",
+                    "last": (r["last_timestamp"] or "")[:16].replace("T", " "),
+                    "last_date": (r["last_timestamp"] or "")[:10],
+                    "duration_min": dur,
+                    "model": r["model"] or "gpt-5",
+                    "turns": r["turn_count"] or 0,
+                    "input": r["total_input_tokens"] or 0,
+                    "output": r["total_output_tokens"] or 0,
+                    "cache_read": r["total_cache_read"] or 0,
+                })
 
         # Combined daily (both providers)
-        combrows = conn2.execute("""
-            SELECT substr(timestamp,1,10) as day,
-                   COALESCE(provider,'claude') as provider,
-                   SUM(input_tokens) as input, SUM(output_tokens) as output,
-                   SUM(cache_read_tokens) as cache_read, COUNT(*) as turns
-            FROM turns GROUP BY day, provider ORDER BY day, provider
-        """).fetchall()
+        if has_turns_provider:
+            combrows = conn2.execute("""
+                SELECT substr(timestamp,1,10) as day,
+                       COALESCE(provider,'claude') as provider,
+                       SUM(input_tokens) as input, SUM(output_tokens) as output,
+                       SUM(cache_read_tokens) as cache_read, COUNT(*) as turns
+                FROM turns GROUP BY day, provider ORDER BY day, provider
+            """).fetchall()
+        else:
+            combrows = conn2.execute("""
+                SELECT substr(timestamp,1,10) as day,
+                       'claude' as provider,
+                       SUM(input_tokens) as input, SUM(output_tokens) as output,
+                       SUM(cache_read_tokens) as cache_read, COUNT(*) as turns
+                FROM turns GROUP BY day ORDER BY day
+            """).fetchall()
         combined_daily_rows = [{
             "day": r["day"], "provider": r["provider"],
             "input": r["input"] or 0, "output": r["output"] or 0,
@@ -247,14 +265,14 @@ def get_dashboard_data(db_path=DB_PATH):
     codex_strip = get_codex_status(db_path)
 
     return {
-        "all_models":     all_models,
-        "daily_by_model": daily_by_model,
-        "sessions_all":   sessions_all,
-        "generated_at":   datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-        "codex_strip":    codex_strip,
-        "codex_daily":    codex_daily_rows,
-        "codex_sessions": codex_sessions_all,
-        "combined_daily": combined_daily_rows,
+        "all_models":          all_models,
+        "daily_by_model":      daily_by_model,
+        "sessions_all":        sessions_all,
+        "generated_at":        datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "codex_strip":         codex_strip,
+        "codex_daily":         codex_daily_rows,
+        "codex_sessions":      codex_sessions_all,
+        "combined_daily":      combined_daily_rows,
     }
 
 
@@ -275,16 +293,120 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
     --accent: #d97757;
     --blue: #4f8ef7;
     --green: #4ade80;
+    --codex: #22c55e;
+    --combined: #60a5fa;
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body { background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; font-size: 14px; }
 
-  header { background: var(--card); border-bottom: 1px solid var(--border); padding: 16px 24px; display: flex; align-items: center; justify-content: space-between; }
+  header { background: var(--card); border-bottom: 1px solid var(--border); padding: 16px 24px; display: flex; align-items: center; justify-content: space-between; gap: 12px; }
   header h1 { font-size: 18px; font-weight: 600; color: var(--accent); }
   header .meta { color: var(--muted); font-size: 12px; }
-  #rescan-btn { background: var(--card); border: 1px solid var(--border); color: var(--muted); padding: 4px 12px; border-radius: 6px; cursor: pointer; font-size: 12px; margin-top: 4px; }
+  #rescan-btn { background: var(--card); border: 1px solid var(--border); color: var(--muted); padding: 4px 12px; border-radius: 6px; cursor: pointer; font-size: 12px; }
   #rescan-btn:hover { color: var(--text); border-color: var(--accent); }
   #rescan-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .tab-bar {
+    background: var(--card);
+    border-bottom: 1px solid var(--border);
+    padding: 0 24px;
+    display: flex;
+    gap: 24px;
+  }
+  .tab-btn {
+    background: transparent;
+    color: var(--muted);
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 12px 0 10px;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+  }
+  .tab-btn:hover { color: var(--text); }
+  .tab-btn.active { color: var(--text); border-bottom-color: var(--accent); }
+
+  .status-strip {
+    max-width: 1400px;
+    margin: 16px auto 0;
+    padding: 0 24px;
+    display: grid;
+    gap: 16px;
+    grid-template-columns: 1fr 1fr;
+  }
+  .status-card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 14px 16px;
+  }
+  .status-title {
+    color: var(--muted);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 10px;
+  }
+  .status-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 14px;
+    align-items: center;
+  }
+  .gauge-wrap { display: flex; align-items: center; gap: 10px; }
+  .gauge {
+    width: 96px;
+    height: 48px;
+    border-radius: 96px 96px 0 0;
+    overflow: hidden;
+    position: relative;
+    background: #2a2d3a;
+    flex-shrink: 0;
+  }
+  .gauge::after {
+    content: '';
+    position: absolute;
+    left: 8px;
+    right: 8px;
+    bottom: 0;
+    height: 40px;
+    border-radius: 88px 88px 0 0;
+    background: var(--card);
+  }
+  .gauge-value {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 7px;
+    text-align: center;
+    font-size: 11px;
+    font-family: monospace;
+    z-index: 1;
+    color: var(--text);
+  }
+  .gauge-meta .glabel { color: var(--muted); font-size: 11px; margin-bottom: 2px; }
+  .gauge-meta .greset { color: var(--text); font-size: 12px; }
+  .chips { margin-top: 10px; display: flex; gap: 8px; flex-wrap: wrap; }
+  .chip {
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 2px 8px;
+    font-size: 11px;
+    color: var(--muted);
+  }
+  .chip.ok { border-color: rgba(74,222,128,0.35); color: #86efac; }
+  .status-placeholder {
+    color: #6b7280;
+    font-size: 13px;
+    border: 1px dashed #374151;
+    border-radius: 6px;
+    padding: 10px 12px;
+    line-height: 1.5;
+  }
+
+  .tab-content { display: none; }
+  .tab-content.active { display: block; }
 
   #filter-bar { background: var(--card); border-bottom: 1px solid var(--border); padding: 10px 24px; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
   .filter-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); white-space: nowrap; }
@@ -335,6 +457,7 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
   .export-btn { background: var(--card); border: 1px solid var(--border); color: var(--muted); padding: 3px 10px; border-radius: 5px; cursor: pointer; font-size: 11px; }
   .export-btn:hover { color: var(--text); border-color: var(--accent); }
   .table-card { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 20px; margin-bottom: 24px; overflow-x: auto; }
+  .list-table td:first-child { max-width: 320px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
   footer { border-top: 1px solid var(--border); padding: 20px 24px; margin-top: 8px; }
   .footer-content { max-width: 1400px; margin: 0 auto; }
@@ -343,30 +466,13 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
   .footer-content a { color: var(--blue); text-decoration: none; }
   .footer-content a:hover { text-decoration: underline; }
 
-  @media (max-width: 768px) { .charts-grid { grid-template-columns: 1fr; } .chart-card.wide { grid-column: 1; } }
-
-  /* Tab bar */
-  .tab-bar { background: var(--card); border-bottom: 1px solid var(--border); padding: 0 24px; display: flex; }
-  .tab-btn { padding: 12px 20px; background: transparent; border: none; border-bottom: 2px solid transparent; color: var(--muted); font-size: 13px; font-weight: 500; cursor: pointer; transition: color 0.15s, border-color 0.15s; }
-  .tab-btn:hover { color: var(--text); }
-  .tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
-  .tab-pane { display: none; }
-  .tab-pane.active { display: block; }
-
-  /* Rate-limit strip */
-  .rl-strip { background: var(--card); border-bottom: 1px solid var(--border); padding: 8px 24px; display: flex; gap: 24px; align-items: center; flex-wrap: wrap; }
-  .rl-col { display: flex; align-items: center; gap: 10px; }
-  .rl-label { font-size: 11px; font-weight: 600; text-transform: uppercase; color: var(--muted); white-space: nowrap; }
-  .rl-gauge { display: flex; align-items: center; gap: 5px; font-size: 12px; }
-  .rl-bar { width: 56px; height: 5px; background: var(--border); border-radius: 3px; overflow: hidden; display: inline-block; vertical-align: middle; }
-  .rl-bar-fill { height: 100%; border-radius: 3px; }
-  .rl-bar-fill.low  { background: var(--green); }
-  .rl-bar-fill.mid  { background: #f59e0b; }
-  .rl-bar-fill.high { background: #ef4444; }
-  .rl-chip { font-size: 11px; padding: 2px 7px; border-radius: 10px; border: 1px solid var(--border); color: var(--muted); }
-  .rl-sep { width: 1px; height: 28px; background: var(--border); flex-shrink: 0; }
-  .rl-placeholder { color: var(--muted); font-size: 12px; font-style: italic; }
-  .rl-fresh { color: var(--muted); font-size: 11px; }
+  @media (max-width: 1024px) { .status-strip { grid-template-columns: 1fr; } }
+  @media (max-width: 768px) {
+    .charts-grid { grid-template-columns: 1fr; }
+    .chart-card.wide { grid-column: 1; }
+    .tab-bar { gap: 14px; overflow-x: auto; }
+    header { flex-wrap: wrap; }
+  }
 </style>
 </head>
 <body>
@@ -377,137 +483,159 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
 </header>
 
 <div class="tab-bar">
-  <button class="tab-btn" id="tab-claude" onclick="switchTab('claude')">Claude</button>
-  <button class="tab-btn" id="tab-codex" onclick="switchTab('codex')">Codex</button>
-  <button class="tab-btn" id="tab-combined" onclick="switchTab('combined')">Combined</button>
+  <button class="tab-btn active" data-tab="claude" onclick="setTab('claude')">Claude</button>
+  <button class="tab-btn" data-tab="codex" onclick="setTab('codex')">Codex</button>
+  <button class="tab-btn" data-tab="combined" onclick="setTab('combined')">Combined</button>
 </div>
 
-<div class="rl-strip">
-  <div class="rl-col">
-    <span class="rl-label">Codex</span>
-    <span id="rl-codex-content"><span class="rl-placeholder">loading…</span></span>
+<div class="status-strip">
+  <div class="status-card">
+    <div class="status-title">Codex Status</div>
+    <div id="codex-strip-body" class="status-grid"></div>
+    <div class="chips" id="codex-strip-chips"></div>
   </div>
-  <div class="rl-sep"></div>
-  <div class="rl-col">
-    <span class="rl-label">Gemini</span>
-    <span class="rl-placeholder">not configured — run <code>gemini auth login</code></span>
-  </div>
-</div>
-
-<div class="tab-pane" id="pane-claude">
-<div id="filter-bar">
-  <div class="filter-label">Models</div>
-  <div id="model-checkboxes"></div>
-  <button class="filter-btn" onclick="selectAllModels()">All</button>
-  <button class="filter-btn" onclick="clearAllModels()">None</button>
-  <div class="filter-sep"></div>
-  <div class="filter-label">Range</div>
-  <div class="range-group">
-    <button class="range-btn" data-range="7d"  onclick="setRange('7d')">7d</button>
-    <button class="range-btn" data-range="30d" onclick="setRange('30d')">30d</button>
-    <button class="range-btn" data-range="90d" onclick="setRange('90d')">90d</button>
-    <button class="range-btn" data-range="all" onclick="setRange('all')">All</button>
+  <div class="status-card">
+    <div class="status-title">Gemini Status</div>
+    <div class="status-placeholder">Gemini: not configured - Run <code>gemini auth login</code></div>
   </div>
 </div>
 
-<div class="container">
-  <div class="stats-row" id="stats-row"></div>
-  <div class="charts-grid">
-    <div class="chart-card wide">
-      <h2 id="daily-chart-title">Daily Token Usage</h2>
-      <div class="chart-wrap tall"><canvas id="chart-daily"></canvas></div>
-    </div>
-    <div class="chart-card">
-      <h2>By Model</h2>
-      <div class="chart-wrap"><canvas id="chart-model"></canvas></div>
-    </div>
-    <div class="chart-card">
-      <h2>Top Projects by Tokens</h2>
-      <div class="chart-wrap"><canvas id="chart-project"></canvas></div>
+<div id="tab-claude" class="tab-content active">
+  <div id="filter-bar">
+    <div class="filter-label">Models</div>
+    <div id="model-checkboxes"></div>
+    <button class="filter-btn" onclick="selectAllModels()">All</button>
+    <button class="filter-btn" onclick="clearAllModels()">None</button>
+    <div class="filter-sep"></div>
+    <div class="filter-label">Range</div>
+    <div class="range-group">
+      <button class="range-btn" data-range="7d" onclick="setRange('7d')">7d</button>
+      <button class="range-btn" data-range="30d" onclick="setRange('30d')">30d</button>
+      <button class="range-btn" data-range="90d" onclick="setRange('90d')">90d</button>
+      <button class="range-btn" data-range="all" onclick="setRange('all')">All</button>
     </div>
   </div>
-  <div class="table-card">
-    <div class="section-title">Cost by Model</div>
-    <table>
-      <thead><tr>
-        <th>Model</th>
-        <th class="sortable" onclick="setModelSort('turns')">Turns <span class="sort-icon" id="msort-turns"></span></th>
-        <th class="sortable" onclick="setModelSort('input')">Input <span class="sort-icon" id="msort-input"></span></th>
-        <th class="sortable" onclick="setModelSort('output')">Output <span class="sort-icon" id="msort-output"></span></th>
-        <th class="sortable" onclick="setModelSort('cache_read')">Cache Read <span class="sort-icon" id="msort-cache_read"></span></th>
-        <th class="sortable" onclick="setModelSort('cache_creation')">Cache Creation <span class="sort-icon" id="msort-cache_creation"></span></th>
-        <th class="sortable" onclick="setModelSort('cost')">Est. Cost <span class="sort-icon" id="msort-cost"></span></th>
-      </tr></thead>
-      <tbody id="model-cost-body"></tbody>
-    </table>
-  </div>
-  <div class="table-card">
-    <div class="section-header"><div class="section-title">Recent Sessions</div><button class="export-btn" onclick="exportSessionsCSV()" title="Export all filtered sessions to CSV">&#x2913; CSV</button></div>
-    <table>
-      <thead><tr>
-        <th>Session</th>
-        <th>Project</th>
-        <th class="sortable" onclick="setSessionSort('last')">Last Active <span class="sort-icon" id="sort-icon-last"></span></th>
-        <th class="sortable" onclick="setSessionSort('duration_min')">Duration <span class="sort-icon" id="sort-icon-duration_min"></span></th>
-        <th>Model</th>
-        <th class="sortable" onclick="setSessionSort('turns')">Turns <span class="sort-icon" id="sort-icon-turns"></span></th>
-        <th class="sortable" onclick="setSessionSort('input')">Input <span class="sort-icon" id="sort-icon-input"></span></th>
-        <th class="sortable" onclick="setSessionSort('output')">Output <span class="sort-icon" id="sort-icon-output"></span></th>
-        <th class="sortable" onclick="setSessionSort('cost')">Est. Cost <span class="sort-icon" id="sort-icon-cost"></span></th>
-      </tr></thead>
-      <tbody id="sessions-body"></tbody>
-    </table>
-  </div>
-  <div class="table-card">
-    <div class="section-header"><div class="section-title">Cost by Project</div><button class="export-btn" onclick="exportProjectsCSV()" title="Export all projects to CSV">&#x2913; CSV</button></div>
-    <table>
-      <thead><tr>
-        <th>Project</th>
-        <th class="sortable" onclick="setProjectSort('sessions')">Sessions <span class="sort-icon" id="psort-sessions"></span></th>
-        <th class="sortable" onclick="setProjectSort('turns')">Turns <span class="sort-icon" id="psort-turns"></span></th>
-        <th class="sortable" onclick="setProjectSort('input')">Input <span class="sort-icon" id="psort-input"></span></th>
-        <th class="sortable" onclick="setProjectSort('output')">Output <span class="sort-icon" id="psort-output"></span></th>
-        <th class="sortable" onclick="setProjectSort('cost')">Est. Cost <span class="sort-icon" id="psort-cost"></span></th>
-      </tr></thead>
-      <tbody id="project-cost-body"></tbody>
-    </table>
-  </div>
-</div>
-</div><!-- end pane-claude -->
 
-<div class="tab-pane" id="pane-codex">
   <div class="container">
-    <div class="stats-row" id="codex-stats-row"></div>
+    <div class="stats-row" id="stats-row"></div>
     <div class="charts-grid">
       <div class="chart-card wide">
-        <h2>Daily Codex Usage</h2>
-        <div class="chart-wrap tall"><canvas id="chart-codex-daily"></canvas></div>
+        <h2 id="daily-chart-title">Daily Token Usage</h2>
+        <div class="chart-wrap tall"><canvas id="chart-daily"></canvas></div>
       </div>
       <div class="chart-card">
         <h2>By Model</h2>
-        <div class="chart-wrap"><canvas id="chart-codex-model"></canvas></div>
+        <div class="chart-wrap"><canvas id="chart-model"></canvas></div>
       </div>
       <div class="chart-card">
-        <h2>Top Projects</h2>
-        <div class="chart-wrap"><canvas id="chart-codex-project"></canvas></div>
+        <h2>Top Projects by Tokens</h2>
+        <div class="chart-wrap"><canvas id="chart-project"></canvas></div>
       </div>
     </div>
     <div class="table-card">
       <div class="section-title">Cost by Model</div>
-      <table><thead><tr>
-        <th>Model</th><th>Turns</th><th>Input</th><th>Output</th><th>Cache Read</th><th>Est. Cost</th>
-      </tr></thead><tbody id="codex-model-cost-body"></tbody></table>
+      <table>
+        <thead><tr>
+          <th>Model</th>
+          <th class="sortable" onclick="setModelSort('turns')">Turns <span class="sort-icon" id="msort-turns"></span></th>
+          <th class="sortable" onclick="setModelSort('input')">Input <span class="sort-icon" id="msort-input"></span></th>
+          <th class="sortable" onclick="setModelSort('output')">Output <span class="sort-icon" id="msort-output"></span></th>
+          <th class="sortable" onclick="setModelSort('cache_read')">Cache Read <span class="sort-icon" id="msort-cache_read"></span></th>
+          <th class="sortable" onclick="setModelSort('cache_creation')">Cache Creation <span class="sort-icon" id="msort-cache_creation"></span></th>
+          <th class="sortable" onclick="setModelSort('cost')">Est. Cost <span class="sort-icon" id="msort-cost"></span></th>
+        </tr></thead>
+        <tbody id="model-cost-body"></tbody>
+      </table>
     </div>
     <div class="table-card">
-      <div class="section-title">Sessions</div>
-      <table><thead><tr>
-        <th>Session</th><th>Project</th><th>Last Active</th><th>Model</th><th>Turns</th><th>Input</th><th>Output</th><th>Est. Cost</th>
-      </tr></thead><tbody id="codex-sessions-body"></tbody></table>
+      <div class="section-header"><div class="section-title">Recent Sessions</div><button class="export-btn" onclick="exportSessionsCSV()" title="Export all filtered sessions to CSV">&#x2913; CSV</button></div>
+      <table>
+        <thead><tr>
+          <th>Session</th>
+          <th>Project</th>
+          <th class="sortable" onclick="setSessionSort('last')">Last Active <span class="sort-icon" id="sort-icon-last"></span></th>
+          <th class="sortable" onclick="setSessionSort('duration_min')">Duration <span class="sort-icon" id="sort-icon-duration_min"></span></th>
+          <th>Model</th>
+          <th class="sortable" onclick="setSessionSort('turns')">Turns <span class="sort-icon" id="sort-icon-turns"></span></th>
+          <th class="sortable" onclick="setSessionSort('input')">Input <span class="sort-icon" id="sort-icon-input"></span></th>
+          <th class="sortable" onclick="setSessionSort('output')">Output <span class="sort-icon" id="sort-icon-output"></span></th>
+          <th class="sortable" onclick="setSessionSort('cost')">Est. Cost <span class="sort-icon" id="sort-icon-cost"></span></th>
+        </tr></thead>
+        <tbody id="sessions-body"></tbody>
+      </table>
+    </div>
+    <div class="table-card">
+      <div class="section-header"><div class="section-title">Cost by Project</div><button class="export-btn" onclick="exportProjectsCSV()" title="Export all projects to CSV">&#x2913; CSV</button></div>
+      <table>
+        <thead><tr>
+          <th>Project</th>
+          <th class="sortable" onclick="setProjectSort('sessions')">Sessions <span class="sort-icon" id="psort-sessions"></span></th>
+          <th class="sortable" onclick="setProjectSort('turns')">Turns <span class="sort-icon" id="psort-turns"></span></th>
+          <th class="sortable" onclick="setProjectSort('input')">Input <span class="sort-icon" id="psort-input"></span></th>
+          <th class="sortable" onclick="setProjectSort('output')">Output <span class="sort-icon" id="psort-output"></span></th>
+          <th class="sortable" onclick="setProjectSort('cost')">Est. Cost <span class="sort-icon" id="psort-cost"></span></th>
+        </tr></thead>
+        <tbody id="project-cost-body"></tbody>
+      </table>
     </div>
   </div>
-</div><!-- end pane-codex -->
+</div>
 
-<div class="tab-pane" id="pane-combined">
+<div id="tab-codex" class="tab-content">
+  <div class="container">
+    <div class="stats-row" id="codex-stats-row"></div>
+    <div class="charts-grid">
+      <div class="chart-card wide">
+        <h2>Codex Daily Usage by Model</h2>
+        <div class="chart-wrap tall"><canvas id="chart-codex-daily"></canvas></div>
+      </div>
+      <div class="chart-card">
+        <h2>Token Distribution</h2>
+        <div class="chart-wrap"><canvas id="chart-codex-token"></canvas></div>
+      </div>
+      <div class="chart-card">
+        <h2>Top Projects by Tokens</h2>
+        <table class="list-table">
+          <thead><tr><th>Project</th><th>Tokens</th><th>Cost</th></tr></thead>
+          <tbody id="codex-top-projects"></tbody>
+        </table>
+      </div>
+    </div>
+    <div class="table-card">
+      <div class="section-title">Codex Sessions</div>
+      <table>
+        <thead><tr>
+          <th>Session</th>
+          <th>Project</th>
+          <th class="sortable" onclick="setCodexSessionSort('last')">Last Active <span class="sort-icon" id="csort-icon-last"></span></th>
+          <th class="sortable" onclick="setCodexSessionSort('duration_min')">Duration <span class="sort-icon" id="csort-icon-duration_min"></span></th>
+          <th>Model</th>
+          <th class="sortable" onclick="setCodexSessionSort('turns')">Turns <span class="sort-icon" id="csort-icon-turns"></span></th>
+          <th class="sortable" onclick="setCodexSessionSort('input')">Input <span class="sort-icon" id="csort-icon-input"></span></th>
+          <th class="sortable" onclick="setCodexSessionSort('output')">Output <span class="sort-icon" id="csort-icon-output"></span></th>
+          <th class="sortable" onclick="setCodexSessionSort('cost')">Est. Cost <span class="sort-icon" id="csort-icon-cost"></span></th>
+        </tr></thead>
+        <tbody id="codex-sessions-body"></tbody>
+      </table>
+    </div>
+    <div class="table-card">
+      <div class="section-title">Codex Cost by Model</div>
+      <table>
+        <thead><tr>
+          <th>Model</th>
+          <th>Turns</th>
+          <th>Input</th>
+          <th>Output</th>
+          <th>Cache Read</th>
+          <th>Est. Cost</th>
+        </tr></thead>
+        <tbody id="codex-model-cost-body"></tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<div id="tab-combined" class="tab-content">
   <div class="container">
     <div class="stats-row" id="combined-stats-row"></div>
     <div class="charts-grid">
@@ -516,16 +644,23 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
         <div class="chart-wrap tall"><canvas id="chart-combined-daily"></canvas></div>
       </div>
       <div class="chart-card">
-        <h2>Token Share by Provider</h2>
-        <div class="chart-wrap"><canvas id="chart-combined-donut"></canvas></div>
+        <h2>Token Distribution (All Providers)</h2>
+        <div class="chart-wrap"><canvas id="chart-combined-token"></canvas></div>
+      </div>
+      <div class="chart-card">
+        <h2>Top Projects (Union)</h2>
+        <table class="list-table">
+          <thead><tr><th>Project</th><th>Sessions</th><th>Turns</th><th>Cost</th></tr></thead>
+          <tbody id="combined-projects-body"></tbody>
+        </table>
       </div>
     </div>
   </div>
-</div><!-- end pane-combined -->
+</div>
 
 <footer>
   <div class="footer-content">
-    <p>Cost estimates based on Anthropic API pricing (<a href="https://claude.com/pricing#api" target="_blank">claude.com/pricing#api</a>) as of April 2026. Only models containing <em>opus</em>, <em>sonnet</em>, or <em>haiku</em> in the name are included in cost calculations. Actual costs for Max/Pro subscribers differ from API pricing.</p>
+    <p>Cost estimates use Anthropic and OpenAI API rates (April 2026). Subscription plans may bill differently than API token pricing.</p>
     <p>
       GitHub: <a href="https://github.com/phuryn/claude-usage" target="_blank">https://github.com/phuryn/claude-usage</a>
       &nbsp;&middot;&nbsp;
@@ -537,36 +672,70 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
 </footer>
 
 <script>
-// ── Helpers ────────────────────────────────────────────────────────────────
 function esc(s) {
   const d = document.createElement('div');
   d.textContent = String(s);
   return d.innerHTML;
 }
 
-// ── State ──────────────────────────────────────────────────────────────────
 let rawData = null;
+window._data = null;
 let selectedModels = new Set();
 let selectedRange = '30d';
+let selectedTab = 'claude';
 let charts = {};
 let sessionSortCol = 'last';
+let sessionSortDir = 'desc';
 let modelSortCol = 'cost';
 let modelSortDir = 'desc';
 let projectSortCol = 'cost';
 let projectSortDir = 'desc';
+let codexSessionSortCol = 'last';
+let codexSessionSortDir = 'desc';
 let lastFilteredSessions = [];
 let lastByProject = [];
-let sessionSortDir = 'desc';
 
-// ── Pricing (Anthropic API, April 2026) ────────────────────────────────────
 const PRICING = {
-  'claude-opus-4-6':   { input:  5.00, output: 25.00, cache_write:  6.25, cache_read: 0.50 },
-  'claude-opus-4-5':   { input:  5.00, output: 25.00, cache_write:  6.25, cache_read: 0.50 },
-  'claude-sonnet-4-6': { input:  3.00, output: 15.00, cache_write:  3.75, cache_read: 0.30 },
-  'claude-sonnet-4-5': { input:  3.00, output: 15.00, cache_write:  3.75, cache_read: 0.30 },
-  'claude-haiku-4-5':  { input:  1.00, output:  5.00, cache_write:  1.25, cache_read: 0.10 },
-  'claude-haiku-4-6':  { input:  1.00, output:  5.00, cache_write:  1.25, cache_read: 0.10 },
+  'claude-opus-4-6': { input: 5.00, output: 25.00, cache_write: 6.25, cache_read: 0.50 },
+  'claude-opus-4-5': { input: 5.00, output: 25.00, cache_write: 6.25, cache_read: 0.50 },
+  'claude-sonnet-4-6': { input: 3.00, output: 15.00, cache_write: 3.75, cache_read: 0.30 },
+  'claude-sonnet-4-5': { input: 3.00, output: 15.00, cache_write: 3.75, cache_read: 0.30 },
+  'claude-haiku-4-5': { input: 1.00, output: 5.00, cache_write: 1.25, cache_read: 0.10 },
+  'claude-haiku-4-6': { input: 1.00, output: 5.00, cache_write: 1.25, cache_read: 0.10 }
 };
+
+const CODEX_PRICING = {
+  'gpt-5': { in: 1.25, cached_in: 0.125, out: 10.0 },
+  'gpt-5.2-codex': { in: 1.25, cached_in: 0.125, out: 10.0 },
+  'gpt-5.3-codex': { in: 1.25, cached_in: 0.125, out: 10.0 }
+};
+function codexCost(model, inp, cached, out) {
+  const p = CODEX_PRICING[model] || CODEX_PRICING['gpt-5'];
+  // inp is already net (uncached) from DB; cached is cache_read_tokens
+  return (inp * p.in + cached * p.cached_in + out * p.out) / 1e6;
+}
+
+const TOKEN_COLORS = {
+  input: 'rgba(79,142,247,0.8)',
+  output: 'rgba(167,139,250,0.8)',
+  cache_read: 'rgba(74,222,128,0.6)',
+  cache_creation: 'rgba(251,191,36,0.6)',
+  codex: 'rgba(34,197,94,0.8)',
+  claude: 'rgba(217,119,87,0.8)'
+};
+const MODEL_COLORS = ['#d97757','#4f8ef7','#4ade80','#a78bfa','#fbbf24','#f472b6','#34d399','#60a5fa'];
+const RANGE_LABELS = { '7d': 'Last 7 Days', '30d': 'Last 30 Days', '90d': 'Last 90 Days', 'all': 'All Time' };
+const RANGE_TICKS = { '7d': 7, '30d': 15, '90d': 13, 'all': 12 };
+
+function fmt(n) {
+  n = Number(n || 0);
+  if (n >= 1e9) return (n/1e9).toFixed(2) + 'B';
+  if (n >= 1e6) return (n/1e6).toFixed(2) + 'M';
+  if (n >= 1e3) return (n/1e3).toFixed(1) + 'K';
+  return n.toLocaleString();
+}
+function fmtCost(c) { return '$' + Number(c || 0).toFixed(4); }
+function fmtCostBig(c) { return '$' + Number(c || 0).toFixed(2); }
 
 function isBillable(model) {
   if (!model) return false;
@@ -581,9 +750,9 @@ function getPricing(model) {
     if (model.startsWith(key)) return PRICING[key];
   }
   const m = model.toLowerCase();
-  if (m.includes('opus'))   return PRICING['claude-opus-4-6'];
+  if (m.includes('opus')) return PRICING['claude-opus-4-6'];
   if (m.includes('sonnet')) return PRICING['claude-sonnet-4-6'];
-  if (m.includes('haiku'))  return PRICING['claude-haiku-4-5'];
+  if (m.includes('haiku')) return PRICING['claude-haiku-4-5'];
   return null;
 }
 
@@ -592,36 +761,17 @@ function calcCost(model, inp, out, cacheRead, cacheCreation) {
   const p = getPricing(model);
   if (!p) return 0;
   return (
-    inp           * p.input       / 1e6 +
-    out           * p.output      / 1e6 +
-    cacheRead     * p.cache_read  / 1e6 +
+    inp * p.input / 1e6 +
+    out * p.output / 1e6 +
+    cacheRead * p.cache_read / 1e6 +
     cacheCreation * p.cache_write / 1e6
   );
 }
 
-// ── Formatting ─────────────────────────────────────────────────────────────
-function fmt(n) {
-  if (n >= 1e9) return (n/1e9).toFixed(2)+'B';
-  if (n >= 1e6) return (n/1e6).toFixed(2)+'M';
-  if (n >= 1e3) return (n/1e3).toFixed(1)+'K';
-  return n.toLocaleString();
+function readURLRange() {
+  const p = new URLSearchParams(window.location.search).get('range');
+  return ['7d', '30d', '90d', 'all'].includes(p) ? p : '30d';
 }
-function fmtCost(c)    { return '$' + c.toFixed(4); }
-function fmtCostBig(c) { return '$' + c.toFixed(2); }
-
-// ── Chart colors ───────────────────────────────────────────────────────────
-const TOKEN_COLORS = {
-  input:          'rgba(79,142,247,0.8)',
-  output:         'rgba(167,139,250,0.8)',
-  cache_read:     'rgba(74,222,128,0.6)',
-  cache_creation: 'rgba(251,191,36,0.6)',
-};
-const MODEL_COLORS = ['#d97757','#4f8ef7','#4ade80','#a78bfa','#fbbf24','#f472b6','#34d399','#60a5fa'];
-
-// ── Time range ─────────────────────────────────────────────────────────────
-const RANGE_LABELS = { '7d': 'Last 7 Days', '30d': 'Last 30 Days', '90d': 'Last 90 Days', 'all': 'All Time' };
-const RANGE_TICKS  = { '7d': 7, '30d': 15, '90d': 13, 'all': 12 };
-
 function getRangeCutoff(range) {
   if (range === 'all') return null;
   const days = range === '7d' ? 7 : range === '30d' ? 30 : 90;
@@ -629,27 +779,36 @@ function getRangeCutoff(range) {
   d.setDate(d.getDate() - days);
   return d.toISOString().slice(0, 10);
 }
-
-function readURLRange() {
-  const p = new URLSearchParams(window.location.search).get('range');
-  return ['7d', '30d', '90d', 'all'].includes(p) ? p : '30d';
+function getRangeCutoffDays(days) {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return d.toISOString().slice(0, 10);
 }
 
 function setRange(range) {
   selectedRange = range;
-  document.querySelectorAll('.range-btn').forEach(btn =>
-    btn.classList.toggle('active', btn.dataset.range === range)
-  );
+  document.querySelectorAll('.range-btn').forEach(btn => btn.classList.toggle('active', btn.dataset.range === range));
   updateURL();
   applyFilter();
 }
 
-// ── Model filter ───────────────────────────────────────────────────────────
+function setTab(tab, persist=true) {
+  selectedTab = tab;
+  document.querySelectorAll('.tab-btn').forEach(btn => btn.classList.toggle('active', btn.dataset.tab === tab));
+  document.querySelectorAll('.tab-content').forEach(div => div.classList.toggle('active', div.id === 'tab-' + tab));
+  if (persist) localStorage.setItem('aidash_tab', tab);
+}
+
+function initTabs() {
+  const saved = localStorage.getItem('aidash_tab');
+  setTab(saved || 'claude', false);
+}
+
 function modelPriority(m) {
   const ml = m.toLowerCase();
-  if (ml.includes('opus'))   return 0;
+  if (ml.includes('opus')) return 0;
   if (ml.includes('sonnet')) return 1;
-  if (ml.includes('haiku'))  return 2;
+  if (ml.includes('haiku')) return 2;
   return 3;
 }
 
@@ -684,27 +843,32 @@ function buildFilterUI(allModels) {
 
 function onModelToggle(cb) {
   const label = cb.closest('label');
-  if (cb.checked) { selectedModels.add(cb.value);    label.classList.add('checked'); }
-  else            { selectedModels.delete(cb.value); label.classList.remove('checked'); }
+  if (cb.checked) { selectedModels.add(cb.value); label.classList.add('checked'); }
+  else { selectedModels.delete(cb.value); label.classList.remove('checked'); }
   updateURL();
   applyFilter();
 }
 
 function selectAllModels() {
   document.querySelectorAll('#model-checkboxes input').forEach(cb => {
-    cb.checked = true; selectedModels.add(cb.value); cb.closest('label').classList.add('checked');
+    cb.checked = true;
+    selectedModels.add(cb.value);
+    cb.closest('label').classList.add('checked');
   });
-  updateURL(); applyFilter();
+  updateURL();
+  applyFilter();
 }
 
 function clearAllModels() {
   document.querySelectorAll('#model-checkboxes input').forEach(cb => {
-    cb.checked = false; selectedModels.delete(cb.value); cb.closest('label').classList.remove('checked');
+    cb.checked = false;
+    selectedModels.delete(cb.value);
+    cb.closest('label').classList.remove('checked');
   });
-  updateURL(); applyFilter();
+  updateURL();
+  applyFilter();
 }
 
-// ── URL persistence ────────────────────────────────────────────────────────
 function updateURL() {
   const allModels = Array.from(document.querySelectorAll('#model-checkboxes input')).map(cb => cb.value);
   const params = new URLSearchParams();
@@ -714,20 +878,15 @@ function updateURL() {
   history.replaceState(null, '', window.location.pathname + search);
 }
 
-// ── Session sort ───────────────────────────────────────────────────────────
 function setSessionSort(col) {
-  if (sessionSortCol === col) {
-    sessionSortDir = sessionSortDir === 'desc' ? 'asc' : 'desc';
-  } else {
-    sessionSortCol = col;
-    sessionSortDir = 'desc';
-  }
+  if (sessionSortCol === col) sessionSortDir = sessionSortDir === 'desc' ? 'asc' : 'desc';
+  else { sessionSortCol = col; sessionSortDir = 'desc'; }
   updateSortIcons();
   applyFilter();
 }
 
 function updateSortIcons() {
-  document.querySelectorAll('.sort-icon').forEach(el => el.textContent = '');
+  document.querySelectorAll('[id^="sort-icon-"]').forEach(el => { el.textContent = ''; });
   const icon = document.getElementById('sort-icon-' + sessionSortCol);
   if (icon) icon.textContent = sessionSortDir === 'desc' ? ' \u25bc' : ' \u25b2';
 }
@@ -751,217 +910,15 @@ function sortSessions(sessions) {
   });
 }
 
-// ── Aggregation & filtering ────────────────────────────────────────────────
-function applyFilter() {
-  if (!rawData) return;
-
-  const cutoff = getRangeCutoff(selectedRange);
-
-  // Filter daily rows by model + date range
-  const filteredDaily = rawData.daily_by_model.filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
-  );
-
-  // Daily chart: aggregate by day
-  const dailyMap = {};
-  for (const r of filteredDaily) {
-    if (!dailyMap[r.day]) dailyMap[r.day] = { day: r.day, input: 0, output: 0, cache_read: 0, cache_creation: 0 };
-    const d = dailyMap[r.day];
-    d.input          += r.input;
-    d.output         += r.output;
-    d.cache_read     += r.cache_read;
-    d.cache_creation += r.cache_creation;
-  }
-  const daily = Object.values(dailyMap).sort((a, b) => a.day.localeCompare(b.day));
-
-  // By model: aggregate tokens + turns from daily data
-  const modelMap = {};
-  for (const r of filteredDaily) {
-    if (!modelMap[r.model]) modelMap[r.model] = { model: r.model, input: 0, output: 0, cache_read: 0, cache_creation: 0, turns: 0, sessions: 0 };
-    const m = modelMap[r.model];
-    m.input          += r.input;
-    m.output         += r.output;
-    m.cache_read     += r.cache_read;
-    m.cache_creation += r.cache_creation;
-    m.turns          += r.turns;
-  }
-
-  // Filter sessions by model + date range
-  const filteredSessions = rawData.sessions_all.filter(s =>
-    selectedModels.has(s.model) && (!cutoff || s.last_date >= cutoff)
-  );
-
-  // Add session counts into modelMap
-  for (const s of filteredSessions) {
-    if (modelMap[s.model]) modelMap[s.model].sessions++;
-  }
-
-  const byModel = Object.values(modelMap).sort((a, b) => (b.input + b.output) - (a.input + a.output));
-
-  // By project: aggregate from filtered sessions
-  const projMap = {};
-  for (const s of filteredSessions) {
-    if (!projMap[s.project]) projMap[s.project] = { project: s.project, input: 0, output: 0, cache_read: 0, cache_creation: 0, turns: 0, sessions: 0, cost: 0 };
-    const p = projMap[s.project];
-    p.input          += s.input;
-    p.output         += s.output;
-    p.cache_read     += s.cache_read;
-    p.cache_creation += s.cache_creation;
-    p.turns          += s.turns;
-    p.sessions++;
-    p.cost += calcCost(s.model, s.input, s.output, s.cache_read, s.cache_creation);
-  }
-  const byProject = Object.values(projMap).sort((a, b) => (b.input + b.output) - (a.input + a.output));
-
-  // Totals
-  const totals = {
-    sessions:       filteredSessions.length,
-    turns:          byModel.reduce((s, m) => s + m.turns, 0),
-    input:          byModel.reduce((s, m) => s + m.input, 0),
-    output:         byModel.reduce((s, m) => s + m.output, 0),
-    cache_read:     byModel.reduce((s, m) => s + m.cache_read, 0),
-    cache_creation: byModel.reduce((s, m) => s + m.cache_creation, 0),
-    cost:           byModel.reduce((s, m) => s + calcCost(m.model, m.input, m.output, m.cache_read, m.cache_creation), 0),
-  };
-
-  // Update daily chart title
-  document.getElementById('daily-chart-title').textContent = 'Daily Token Usage \u2014 ' + RANGE_LABELS[selectedRange];
-
-  renderStats(totals);
-  renderDailyChart(daily);
-  renderModelChart(byModel);
-  renderProjectChart(byProject);
-  lastFilteredSessions = sortSessions(filteredSessions);
-  lastByProject = sortProjects(byProject);
-  renderSessionsTable(lastFilteredSessions.slice(0, 20));
-  renderModelCostTable(byModel);
-  renderProjectCostTable(lastByProject.slice(0, 20));
-}
-
-// ── Renderers ──────────────────────────────────────────────────────────────
-function renderStats(t) {
-  const rangeLabel = RANGE_LABELS[selectedRange].toLowerCase();
-  const stats = [
-    { label: 'Sessions',       value: t.sessions.toLocaleString(), sub: rangeLabel },
-    { label: 'Turns',          value: fmt(t.turns),                sub: rangeLabel },
-    { label: 'Input Tokens',   value: fmt(t.input),                sub: rangeLabel },
-    { label: 'Output Tokens',  value: fmt(t.output),               sub: rangeLabel },
-    { label: 'Cache Read',     value: fmt(t.cache_read),           sub: 'from prompt cache' },
-    { label: 'Cache Creation', value: fmt(t.cache_creation),       sub: 'writes to prompt cache' },
-    { label: 'Est. Cost',      value: fmtCostBig(t.cost),          sub: 'API pricing, Apr 2026', color: '#4ade80' },
-  ];
-  document.getElementById('stats-row').innerHTML = stats.map(s => `
-    <div class="stat-card">
-      <div class="label">${s.label}</div>
-      <div class="value" style="${s.color ? 'color:' + s.color : ''}">${esc(s.value)}</div>
-      ${s.sub ? `<div class="sub">${esc(s.sub)}</div>` : ''}
-    </div>
-  `).join('');
-}
-
-function renderDailyChart(daily) {
-  const ctx = document.getElementById('chart-daily').getContext('2d');
-  if (charts.daily) charts.daily.destroy();
-  charts.daily = new Chart(ctx, {
-    type: 'bar',
-    data: {
-      labels: daily.map(d => d.day),
-      datasets: [
-        { label: 'Input',          data: daily.map(d => d.input),          backgroundColor: TOKEN_COLORS.input,          stack: 'tokens' },
-        { label: 'Output',         data: daily.map(d => d.output),         backgroundColor: TOKEN_COLORS.output,         stack: 'tokens' },
-        { label: 'Cache Read',     data: daily.map(d => d.cache_read),     backgroundColor: TOKEN_COLORS.cache_read,     stack: 'tokens' },
-        { label: 'Cache Creation', data: daily.map(d => d.cache_creation), backgroundColor: TOKEN_COLORS.cache_creation, stack: 'tokens' },
-      ]
-    },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { labels: { color: '#8892a4', boxWidth: 12 } } },
-      scales: {
-        x: { ticks: { color: '#8892a4', maxTicksLimit: RANGE_TICKS[selectedRange] }, grid: { color: '#2a2d3a' } },
-        y: { ticks: { color: '#8892a4', callback: v => fmt(v) }, grid: { color: '#2a2d3a' } },
-      }
-    }
-  });
-}
-
-function renderModelChart(byModel) {
-  const ctx = document.getElementById('chart-model').getContext('2d');
-  if (charts.model) charts.model.destroy();
-  if (!byModel.length) { charts.model = null; return; }
-  charts.model = new Chart(ctx, {
-    type: 'doughnut',
-    data: {
-      labels: byModel.map(m => m.model),
-      datasets: [{ data: byModel.map(m => m.input + m.output), backgroundColor: MODEL_COLORS, borderWidth: 2, borderColor: '#1a1d27' }]
-    },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      plugins: {
-        legend: { position: 'bottom', labels: { color: '#8892a4', boxWidth: 12, font: { size: 11 } } },
-        tooltip: { callbacks: { label: ctx => ` ${ctx.label}: ${fmt(ctx.raw)} tokens` } }
-      }
-    }
-  });
-}
-
-function renderProjectChart(byProject) {
-  const top = byProject.slice(0, 10);
-  const ctx = document.getElementById('chart-project').getContext('2d');
-  if (charts.project) charts.project.destroy();
-  if (!top.length) { charts.project = null; return; }
-  charts.project = new Chart(ctx, {
-    type: 'bar',
-    data: {
-      labels: top.map(p => p.project.length > 22 ? '\u2026' + p.project.slice(-20) : p.project),
-      datasets: [
-        { label: 'Input',  data: top.map(p => p.input),  backgroundColor: TOKEN_COLORS.input },
-        { label: 'Output', data: top.map(p => p.output), backgroundColor: TOKEN_COLORS.output },
-      ]
-    },
-    options: {
-      indexAxis: 'y', responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { labels: { color: '#8892a4', boxWidth: 12 } } },
-      scales: {
-        x: { ticks: { color: '#8892a4', callback: v => fmt(v) }, grid: { color: '#2a2d3a' } },
-        y: { ticks: { color: '#8892a4', font: { size: 11 } }, grid: { color: '#2a2d3a' } },
-      }
-    }
-  });
-}
-
-function renderSessionsTable(sessions) {
-  document.getElementById('sessions-body').innerHTML = sessions.map(s => {
-    const cost = calcCost(s.model, s.input, s.output, s.cache_read, s.cache_creation);
-    const costCell = isBillable(s.model)
-      ? `<td class="cost">${fmtCost(cost)}</td>`
-      : `<td class="cost-na">n/a</td>`;
-    return `<tr>
-      <td class="muted" style="font-family:monospace">${esc(s.session_id)}&hellip;</td>
-      <td>${esc(s.project)}</td>
-      <td class="muted">${esc(s.last)}</td>
-      <td class="muted">${esc(s.duration_min)}m</td>
-      <td><span class="model-tag">${esc(s.model)}</span></td>
-      <td class="num">${s.turns}</td>
-      <td class="num">${fmt(s.input)}</td>
-      <td class="num">${fmt(s.output)}</td>
-      ${costCell}
-    </tr>`;
-  }).join('');
-}
-
 function setModelSort(col) {
-  if (modelSortCol === col) {
-    modelSortDir = modelSortDir === 'desc' ? 'asc' : 'desc';
-  } else {
-    modelSortCol = col;
-    modelSortDir = 'desc';
-  }
+  if (modelSortCol === col) modelSortDir = modelSortDir === 'desc' ? 'asc' : 'desc';
+  else { modelSortCol = col; modelSortDir = 'desc'; }
   updateModelSortIcons();
   applyFilter();
 }
 
 function updateModelSortIcons() {
-  document.querySelectorAll('[id^="msort-"]').forEach(el => el.textContent = '');
+  document.querySelectorAll('[id^="msort-"]').forEach(el => { el.textContent = ''; });
   const icon = document.getElementById('msort-' + modelSortCol);
   if (icon) icon.textContent = modelSortDir === 'desc' ? ' \u25bc' : ' \u25b2';
 }
@@ -982,38 +939,15 @@ function sortModels(byModel) {
   });
 }
 
-function renderModelCostTable(byModel) {
-  document.getElementById('model-cost-body').innerHTML = sortModels(byModel).map(m => {
-    const cost = calcCost(m.model, m.input, m.output, m.cache_read, m.cache_creation);
-    const costCell = isBillable(m.model)
-      ? `<td class="cost">${fmtCost(cost)}</td>`
-      : `<td class="cost-na">n/a</td>`;
-    return `<tr>
-      <td><span class="model-tag">${esc(m.model)}</span></td>
-      <td class="num">${fmt(m.turns)}</td>
-      <td class="num">${fmt(m.input)}</td>
-      <td class="num">${fmt(m.output)}</td>
-      <td class="num">${fmt(m.cache_read)}</td>
-      <td class="num">${fmt(m.cache_creation)}</td>
-      ${costCell}
-    </tr>`;
-  }).join('');
-}
-
-// ── Project cost table sorting ────────────────────────────────────────────
 function setProjectSort(col) {
-  if (projectSortCol === col) {
-    projectSortDir = projectSortDir === 'desc' ? 'asc' : 'desc';
-  } else {
-    projectSortCol = col;
-    projectSortDir = 'desc';
-  }
+  if (projectSortCol === col) projectSortDir = projectSortDir === 'desc' ? 'asc' : 'desc';
+  else { projectSortCol = col; projectSortDir = 'desc'; }
   updateProjectSortIcons();
   applyFilter();
 }
 
 function updateProjectSortIcons() {
-  document.querySelectorAll('[id^="psort-"]').forEach(el => el.textContent = '');
+  document.querySelectorAll('[id^="psort-"]').forEach(el => { el.textContent = ''; });
   const icon = document.getElementById('psort-' + projectSortCol);
   if (icon) icon.textContent = projectSortDir === 'desc' ? ' \u25bc' : ' \u25b2';
 }
@@ -1028,39 +962,544 @@ function sortProjects(byProject) {
   });
 }
 
-function renderProjectCostTable(byProject) {
-  document.getElementById('project-cost-body').innerHTML = sortProjects(byProject).map(p => {
+function applyFilter() {
+  if (!rawData) return;
+  const cutoff = getRangeCutoff(selectedRange);
+
+  const filteredDaily = (rawData.daily_by_model || []).filter(r => selectedModels.has(r.model) && (!cutoff || r.day >= cutoff));
+  const dailyMap = {};
+  for (const r of filteredDaily) {
+    if (!dailyMap[r.day]) dailyMap[r.day] = { day: r.day, input: 0, output: 0, cache_read: 0, cache_creation: 0 };
+    const d = dailyMap[r.day];
+    d.input += r.input || 0;
+    d.output += r.output || 0;
+    d.cache_read += r.cache_read || 0;
+    d.cache_creation += r.cache_creation || 0;
+  }
+  const daily = Object.values(dailyMap).sort((a, b) => a.day.localeCompare(b.day));
+
+  const modelMap = {};
+  for (const r of filteredDaily) {
+    if (!modelMap[r.model]) modelMap[r.model] = { model: r.model, input: 0, output: 0, cache_read: 0, cache_creation: 0, turns: 0, sessions: 0 };
+    const m = modelMap[r.model];
+    m.input += r.input || 0;
+    m.output += r.output || 0;
+    m.cache_read += r.cache_read || 0;
+    m.cache_creation += r.cache_creation || 0;
+    m.turns += r.turns || 0;
+  }
+
+  const filteredSessions = (rawData.sessions_all || []).filter(s => selectedModels.has(s.model) && (!cutoff || s.last_date >= cutoff));
+  for (const s of filteredSessions) if (modelMap[s.model]) modelMap[s.model].sessions++;
+  const byModel = Object.values(modelMap).sort((a, b) => (b.input + b.output) - (a.input + a.output));
+
+  const projMap = {};
+  for (const s of filteredSessions) {
+    if (!projMap[s.project]) projMap[s.project] = { project: s.project, input: 0, output: 0, cache_read: 0, cache_creation: 0, turns: 0, sessions: 0, cost: 0 };
+    const p = projMap[s.project];
+    p.input += s.input || 0;
+    p.output += s.output || 0;
+    p.cache_read += s.cache_read || 0;
+    p.cache_creation += s.cache_creation || 0;
+    p.turns += s.turns || 0;
+    p.sessions++;
+    p.cost += calcCost(s.model, s.input, s.output, s.cache_read, s.cache_creation);
+  }
+  const byProject = Object.values(projMap).sort((a, b) => (b.input + b.output) - (a.input + a.output));
+
+  const totals = {
+    sessions: filteredSessions.length,
+    turns: byModel.reduce((s, m) => s + m.turns, 0),
+    input: byModel.reduce((s, m) => s + m.input, 0),
+    output: byModel.reduce((s, m) => s + m.output, 0),
+    cache_read: byModel.reduce((s, m) => s + m.cache_read, 0),
+    cache_creation: byModel.reduce((s, m) => s + m.cache_creation, 0),
+    cost: byModel.reduce((s, m) => s + calcCost(m.model, m.input, m.output, m.cache_read, m.cache_creation), 0)
+  };
+
+  document.getElementById('daily-chart-title').textContent = 'Daily Token Usage - ' + RANGE_LABELS[selectedRange];
+  renderClaudeStats(totals);
+  renderDailyChart(daily);
+  renderModelChart(byModel);
+  renderProjectChart(byProject);
+  lastFilteredSessions = sortSessions(filteredSessions);
+  lastByProject = sortProjects(byProject);
+  renderSessionsTable(lastFilteredSessions.slice(0, 20));
+  renderModelCostTable(byModel);
+  renderProjectCostTable(lastByProject.slice(0, 20));
+
+  renderCodexTab();
+  renderCombinedTab();
+}
+
+function renderClaudeStats(t) {
+  const rangeLabel = RANGE_LABELS[selectedRange].toLowerCase();
+  const stats = [
+    { label: 'Sessions', value: t.sessions.toLocaleString(), sub: rangeLabel },
+    { label: 'Turns', value: fmt(t.turns), sub: rangeLabel },
+    { label: 'Input Tokens', value: fmt(t.input), sub: rangeLabel },
+    { label: 'Output Tokens', value: fmt(t.output), sub: rangeLabel },
+    { label: 'Cache Read', value: fmt(t.cache_read), sub: 'from prompt cache' },
+    { label: 'Cache Creation', value: fmt(t.cache_creation), sub: 'writes to prompt cache' },
+    { label: 'Est. Cost', value: fmtCostBig(t.cost), sub: 'API pricing, Apr 2026', color: '#4ade80' }
+  ];
+  document.getElementById('stats-row').innerHTML = stats.map(s => `
+    <div class="stat-card">
+      <div class="label">${s.label}</div>
+      <div class="value" style="${s.color ? 'color:' + s.color : ''}">${esc(s.value)}</div>
+      ${s.sub ? `<div class="sub">${esc(s.sub)}</div>` : ''}
+    </div>
+  `).join('');
+}
+
+function renderDailyChart(daily) {
+  const ctx = document.getElementById('chart-daily').getContext('2d');
+  if (charts.daily) charts.daily.destroy();
+  charts.daily = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: daily.map(d => d.day),
+      datasets: [
+        { label: 'Input', data: daily.map(d => d.input), backgroundColor: TOKEN_COLORS.input, stack: 'tokens' },
+        { label: 'Output', data: daily.map(d => d.output), backgroundColor: TOKEN_COLORS.output, stack: 'tokens' },
+        { label: 'Cache Read', data: daily.map(d => d.cache_read), backgroundColor: TOKEN_COLORS.cache_read, stack: 'tokens' },
+        { label: 'Cache Creation', data: daily.map(d => d.cache_creation), backgroundColor: TOKEN_COLORS.cache_creation, stack: 'tokens' }
+      ]
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { labels: { color: '#8892a4', boxWidth: 12 } } },
+      scales: {
+        x: { ticks: { color: '#8892a4', maxTicksLimit: RANGE_TICKS[selectedRange] }, grid: { color: '#2a2d3a' } },
+        y: { ticks: { color: '#8892a4', callback: v => fmt(v) }, grid: { color: '#2a2d3a' } }
+      }
+    }
+  });
+}
+
+function renderModelChart(byModel) {
+  const ctx = document.getElementById('chart-model').getContext('2d');
+  if (charts.model) charts.model.destroy();
+  if (!byModel.length) return;
+  charts.model = new Chart(ctx, {
+    type: 'doughnut',
+    data: {
+      labels: byModel.map(m => m.model),
+      datasets: [{ data: byModel.map(m => (m.input || 0) + (m.output || 0)), backgroundColor: MODEL_COLORS, borderWidth: 2, borderColor: '#1a1d27' }]
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: {
+        legend: { position: 'bottom', labels: { color: '#8892a4', boxWidth: 12, font: { size: 11 } } },
+        tooltip: { callbacks: { label: ctx => ` ${ctx.label}: ${fmt(ctx.raw)} tokens` } }
+      }
+    }
+  });
+}
+
+function renderProjectChart(byProject) {
+  const top = byProject.slice(0, 10);
+  const ctx = document.getElementById('chart-project').getContext('2d');
+  if (charts.project) charts.project.destroy();
+  if (!top.length) return;
+  charts.project = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: top.map(p => p.project.length > 22 ? '...' + p.project.slice(-20) : p.project),
+      datasets: [
+        { label: 'Input', data: top.map(p => p.input), backgroundColor: TOKEN_COLORS.input },
+        { label: 'Output', data: top.map(p => p.output), backgroundColor: TOKEN_COLORS.output }
+      ]
+    },
+    options: {
+      indexAxis: 'y', responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { labels: { color: '#8892a4', boxWidth: 12 } } },
+      scales: {
+        x: { ticks: { color: '#8892a4', callback: v => fmt(v) }, grid: { color: '#2a2d3a' } },
+        y: { ticks: { color: '#8892a4', font: { size: 11 } }, grid: { color: '#2a2d3a' } }
+      }
+    }
+  });
+}
+
+function renderSessionsTable(sessions) {
+  document.getElementById('sessions-body').innerHTML = sessions.map(s => {
+    const cost = calcCost(s.model, s.input, s.output, s.cache_read, s.cache_creation);
+    const costCell = isBillable(s.model) ? `<td class="cost">${fmtCost(cost)}</td>` : `<td class="cost-na">n/a</td>`;
     return `<tr>
+      <td class="muted" style="font-family:monospace">${esc(s.session_id)}&hellip;</td>
+      <td>${esc(s.project)}</td>
+      <td class="muted">${esc(s.last)}</td>
+      <td class="muted">${esc(s.duration_min)}m</td>
+      <td><span class="model-tag">${esc(s.model)}</span></td>
+      <td class="num">${s.turns}</td>
+      <td class="num">${fmt(s.input)}</td>
+      <td class="num">${fmt(s.output)}</td>
+      ${costCell}
+    </tr>`;
+  }).join('');
+}
+
+function renderModelCostTable(byModel) {
+  document.getElementById('model-cost-body').innerHTML = sortModels(byModel).map(m => {
+    const cost = calcCost(m.model, m.input, m.output, m.cache_read, m.cache_creation);
+    const costCell = isBillable(m.model) ? `<td class="cost">${fmtCost(cost)}</td>` : `<td class="cost-na">n/a</td>`;
+    return `<tr>
+      <td><span class="model-tag">${esc(m.model)}</span></td>
+      <td class="num">${fmt(m.turns)}</td>
+      <td class="num">${fmt(m.input)}</td>
+      <td class="num">${fmt(m.output)}</td>
+      <td class="num">${fmt(m.cache_read)}</td>
+      <td class="num">${fmt(m.cache_creation)}</td>
+      ${costCell}
+    </tr>`;
+  }).join('');
+}
+
+function renderProjectCostTable(byProject) {
+  document.getElementById('project-cost-body').innerHTML = sortProjects(byProject).map(p => `<tr>
       <td>${esc(p.project)}</td>
       <td class="num">${p.sessions}</td>
       <td class="num">${fmt(p.turns)}</td>
       <td class="num">${fmt(p.input)}</td>
       <td class="num">${fmt(p.output)}</td>
       <td class="cost">${fmtCost(p.cost)}</td>
-    </tr>`;
-  }).join('');
+    </tr>`).join('');
 }
 
-// ── CSV Export ────────────────────────────────────────────────────────────
+function freshnessLabel(sec) {
+  sec = Number(sec || 0);
+  if (sec < 60) return 'fresh now';
+  if (sec < 3600) return `${Math.floor(sec/60)}m old`;
+  return `${Math.floor(sec/3600)}h old`;
+}
+
+function gaugeHTML(label, pct, resets) {
+  const p = Math.max(0, Math.min(100, Number(pct || 0)));
+  const deg = Math.round(p * 1.8);
+  const bg = `conic-gradient(from 180deg, #22c55e 0deg ${deg}deg, #2a2d3a ${deg}deg 180deg)`;
+  return `<div class="gauge-wrap">
+    <div class="gauge" style="background:${bg}">
+      <div class="gauge-value">${p.toFixed(0)}%</div>
+    </div>
+    <div class="gauge-meta">
+      <div class="glabel">${esc(label)}</div>
+      <div class="greset">${esc(resets || 'n/a')}</div>
+    </div>
+  </div>`;
+}
+
+function renderCodexStrip(strip) {
+  const body = document.getElementById('codex-strip-body');
+  const chips = document.getElementById('codex-strip-chips');
+  if (!strip || strip.state === 'unavailable') {
+    body.innerHTML = '<div class="muted">No Codex rate-limit data yet. Run `python cli.py scan --provider codex` first.</div>';
+    chips.innerHTML = '<span class="chip">source: none</span>';
+    return;
+  }
+  body.innerHTML = [
+    gaugeHTML('5hr Window', strip.primary_pct, strip.primary_resets_str),
+    gaugeHTML('7d Window', strip.secondary_pct, strip.secondary_resets_str)
+  ].join('');
+  chips.innerHTML = [
+    `<span class="chip ok">${esc(freshnessLabel(strip.freshness_s))}</span>`,
+    `<span class="chip">${esc(strip.plan_type || 'Plan: unknown')}</span>`,
+    `<span class="chip">${esc(strip.source || 'source')}</span>`
+  ].join('');
+}
+
+function aggregateCodexByModel(rows, cutoff=null) {
+  const map = {};
+  for (const r of rows || []) {
+    if (cutoff && r.day < cutoff) continue;
+    if (!map[r.model]) map[r.model] = { model: r.model, input: 0, output: 0, cache_read: 0, turns: 0 };
+    const m = map[r.model];
+    m.input += r.input || 0;
+    m.output += r.output || 0;
+    m.cache_read += r.cache_read || 0;
+    m.turns += r.turns || 0;
+  }
+  return Object.values(map).sort((a, b) => (b.input + b.output + b.cache_read) - (a.input + a.output + a.cache_read));
+}
+
+function setCodexSessionSort(col) {
+  if (codexSessionSortCol === col) codexSessionSortDir = codexSessionSortDir === 'desc' ? 'asc' : 'desc';
+  else { codexSessionSortCol = col; codexSessionSortDir = 'desc'; }
+  updateCodexSortIcons();
+  renderCodexTab();
+}
+
+function updateCodexSortIcons() {
+  document.querySelectorAll('[id^="csort-icon-"]').forEach(el => { el.textContent = ''; });
+  const icon = document.getElementById('csort-icon-' + codexSessionSortCol);
+  if (icon) icon.textContent = codexSessionSortDir === 'desc' ? ' \u25bc' : ' \u25b2';
+}
+
+function sortCodexSessions(rows) {
+  return [...rows].sort((a, b) => {
+    let av, bv;
+    if (codexSessionSortCol === 'cost') {
+      av = codexCost(a.model, a.input, a.cache_read, a.output);
+      bv = codexCost(b.model, b.input, b.cache_read, b.output);
+    } else if (codexSessionSortCol === 'duration_min') {
+      av = parseFloat(a.duration_min) || 0;
+      bv = parseFloat(b.duration_min) || 0;
+    } else {
+      av = a[codexSessionSortCol] ?? 0;
+      bv = b[codexSessionSortCol] ?? 0;
+    }
+    if (av < bv) return codexSessionSortDir === 'desc' ? 1 : -1;
+    if (av > bv) return codexSessionSortDir === 'desc' ? -1 : 1;
+    return 0;
+  });
+}
+
+function renderCodexTab() {
+  const daily = rawData.codex_daily || [];
+  const sessions = rawData.codex_sessions || [];
+  const cutoff = getRangeCutoff(selectedRange);
+  const cutoff7 = getRangeCutoffDays(7);
+  const byModelAll = aggregateCodexByModel(daily, null);
+  const byModelRange = aggregateCodexByModel(daily, cutoff);
+  const byModel7 = aggregateCodexByModel(daily, cutoff7);
+  const allCost = byModelAll.reduce((s, m) => s + codexCost(m.model, m.input, m.cache_read, m.output), 0);
+  const sevenCost = byModel7.reduce((s, m) => s + codexCost(m.model, m.input, m.cache_read, m.output), 0);
+  const topModel = byModelAll.length ? byModelAll[0].model : 'n/a';
+  const turns = byModelAll.reduce((s, m) => s + (m.turns || 0), 0);
+
+  const stats = [
+    { label: 'Sessions', value: sessions.length.toLocaleString(), sub: 'all-time' },
+    { label: 'Turns', value: fmt(turns), sub: 'all-time' },
+    { label: 'Cost (7d)', value: fmtCostBig(sevenCost), sub: 'OpenAI API pricing', color: '#4ade80' },
+    { label: 'Cost (All)', value: fmtCostBig(allCost), sub: 'OpenAI API pricing', color: '#4ade80' },
+    { label: 'Top Model', value: topModel, sub: 'by token volume' }
+  ];
+  document.getElementById('codex-stats-row').innerHTML = stats.map(s => `
+    <div class="stat-card">
+      <div class="label">${s.label}</div>
+      <div class="value" style="${s.color ? 'color:' + s.color : ''}">${esc(s.value)}</div>
+      ${s.sub ? `<div class="sub">${esc(s.sub)}</div>` : ''}
+    </div>
+  `).join('');
+
+  const dayMap = {};
+  for (const r of daily) {
+    if (cutoff && r.day < cutoff) continue;
+    if (!dayMap[r.day]) dayMap[r.day] = {};
+    dayMap[r.day][r.model] = (dayMap[r.day][r.model] || 0) + (r.input || 0) + (r.output || 0) + (r.cache_read || 0);
+  }
+  const days = Object.keys(dayMap).sort();
+  const models = [...new Set(byModelRange.map(m => m.model))];
+  const codexDatasets = models.map((m, i) => ({
+    label: m,
+    data: days.map(day => dayMap[day][m] || 0),
+    backgroundColor: MODEL_COLORS[i % MODEL_COLORS.length],
+    stack: 'codex'
+  }));
+  if (charts.codexDaily) charts.codexDaily.destroy();
+  charts.codexDaily = new Chart(document.getElementById('chart-codex-daily').getContext('2d'), {
+    type: 'bar',
+    data: { labels: days, datasets: codexDatasets },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { labels: { color: '#8892a4', boxWidth: 12 } } },
+      scales: {
+        x: { ticks: { color: '#8892a4', maxTicksLimit: RANGE_TICKS[selectedRange] }, grid: { color: '#2a2d3a' } },
+        y: { ticks: { color: '#8892a4', callback: v => fmt(v) }, grid: { color: '#2a2d3a' } }
+      }
+    }
+  });
+
+  const rangeTotals = byModelRange.reduce((acc, m) => {
+    acc.input += m.input || 0;
+    acc.output += m.output || 0;
+    acc.cache_read += m.cache_read || 0;
+    return acc;
+  }, { input: 0, output: 0, cache_read: 0 });
+  if (charts.codexToken) charts.codexToken.destroy();
+  charts.codexToken = new Chart(document.getElementById('chart-codex-token').getContext('2d'), {
+    type: 'doughnut',
+    data: {
+      labels: ['Input', 'Cached Input', 'Output'],
+      datasets: [{ data: [rangeTotals.input, rangeTotals.cache_read, rangeTotals.output], backgroundColor: [TOKEN_COLORS.input, TOKEN_COLORS.cache_read, TOKEN_COLORS.output], borderWidth: 2, borderColor: '#1a1d27' }]
+    },
+    options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { position: 'bottom', labels: { color: '#8892a4', boxWidth: 12 } } } }
+  });
+
+  const projectMap = {};
+  for (const s of sessions) {
+    if (cutoff && s.last_date < cutoff) continue;
+    if (!projectMap[s.project]) projectMap[s.project] = { project: s.project, tokens: 0, cost: 0 };
+    const p = projectMap[s.project];
+    p.tokens += (s.input || 0) + (s.output || 0) + (s.cache_read || 0);
+    p.cost += codexCost(s.model, s.input || 0, s.cache_read || 0, s.output || 0);
+  }
+  const topProjects = Object.values(projectMap).sort((a, b) => b.tokens - a.tokens).slice(0, 10);
+  document.getElementById('codex-top-projects').innerHTML = topProjects.map(p => `<tr>
+      <td>${esc(p.project)}</td><td class="num">${fmt(p.tokens)}</td><td class="cost">${fmtCost(p.cost)}</td>
+    </tr>`).join('');
+
+  const sessionRows = sortCodexSessions(sessions.filter(s => !cutoff || s.last_date >= cutoff)).slice(0, 50);
+  document.getElementById('codex-sessions-body').innerHTML = sessionRows.map(s => `<tr>
+      <td class="muted" style="font-family:monospace">${esc(s.session_id)}&hellip;</td>
+      <td>${esc(s.project)}</td>
+      <td class="muted">${esc(s.last)}</td>
+      <td class="muted">${esc(s.duration_min)}m</td>
+      <td><span class="model-tag">${esc(s.model)}</span></td>
+      <td class="num">${fmt(s.turns)}</td>
+      <td class="num">${fmt(s.input)}</td>
+      <td class="num">${fmt(s.output)}</td>
+      <td class="cost">${fmtCost(codexCost(s.model, s.input, s.cache_read, s.output))}</td>
+    </tr>`).join('');
+
+  document.getElementById('codex-model-cost-body').innerHTML = byModelAll.map(m => `<tr>
+      <td><span class="model-tag">${esc(m.model)}</span></td>
+      <td class="num">${fmt(m.turns)}</td>
+      <td class="num">${fmt(m.input)}</td>
+      <td class="num">${fmt(m.output)}</td>
+      <td class="num">${fmt(m.cache_read)}</td>
+      <td class="cost">${fmtCost(codexCost(m.model, m.input, m.cache_read, m.output))}</td>
+    </tr>`).join('');
+}
+
+function renderCombinedTab() {
+  const cutoff = getRangeCutoff(selectedRange);
+  const cutoff7 = getRangeCutoffDays(7);
+  const claudeDailyAll = rawData.daily_by_model || [];
+  const codexDailyAll = rawData.codex_daily || [];
+  const combinedDaily = rawData.combined_daily || [];
+  const claudeSessions = rawData.sessions_all || [];
+  const codexSessions = rawData.codex_sessions || [];
+
+  function claudeCostFromDaily(rows, c) {
+    const map = {};
+    for (const r of rows) {
+      if (c && r.day < c) continue;
+      if (!map[r.model]) map[r.model] = { input: 0, output: 0, cache_read: 0, cache_creation: 0 };
+      map[r.model].input += r.input || 0;
+      map[r.model].output += r.output || 0;
+      map[r.model].cache_read += r.cache_read || 0;
+      map[r.model].cache_creation += r.cache_creation || 0;
+    }
+    let total = 0;
+    for (const [model, t] of Object.entries(map)) total += calcCost(model, t.input, t.output, t.cache_read, t.cache_creation);
+    return total;
+  }
+  function codexCostFromDaily(rows, c) {
+    const byModel = aggregateCodexByModel(rows, c);
+    return byModel.reduce((s, m) => s + codexCost(m.model, m.input, m.cache_read, m.output), 0);
+  }
+
+  const claudeCostAll = claudeCostFromDaily(claudeDailyAll, null);
+  const codexCostAll = codexCostFromDaily(codexDailyAll, null);
+  const claudeCost7 = claudeCostFromDaily(claudeDailyAll, cutoff7);
+  const codexCost7 = codexCostFromDaily(codexDailyAll, cutoff7);
+  const totalTurns = (claudeDailyAll.reduce((s, r) => s + (r.turns || 0), 0) + codexDailyAll.reduce((s, r) => s + (r.turns || 0), 0));
+
+  const stats = [
+    { label: 'Cost (7d)', value: fmtCostBig(claudeCost7 + codexCost7), sub: 'Claude + Codex', color: '#4ade80' },
+    { label: 'Cost (All)', value: fmtCostBig(claudeCostAll + codexCostAll), sub: 'Claude + Codex', color: '#4ade80' },
+    { label: 'Claude Cost', value: fmtCostBig(claudeCostAll), sub: 'all-time' },
+    { label: 'Codex Cost', value: fmtCostBig(codexCostAll), sub: 'all-time' },
+    { label: 'Sessions', value: (claudeSessions.length + codexSessions.length).toLocaleString(), sub: 'all providers' },
+    { label: 'Turns', value: fmt(totalTurns), sub: 'all providers' }
+  ];
+  document.getElementById('combined-stats-row').innerHTML = stats.map(s => `
+    <div class="stat-card">
+      <div class="label">${s.label}</div>
+      <div class="value" style="${s.color ? 'color:' + s.color : ''}">${esc(s.value)}</div>
+      ${s.sub ? `<div class="sub">${esc(s.sub)}</div>` : ''}
+    </div>
+  `).join('');
+
+  const dayMap = {};
+  for (const r of combinedDaily) {
+    if (cutoff && r.day < cutoff) continue;
+    if (!dayMap[r.day]) dayMap[r.day] = { claude: 0, codex: 0 };
+    const provider = (r.provider || 'claude') === 'codex' ? 'codex' : 'claude';
+    dayMap[r.day][provider] += (r.input || 0) + (r.output || 0) + (r.cache_read || 0);
+  }
+  const days = Object.keys(dayMap).sort();
+  if (charts.combinedDaily) charts.combinedDaily.destroy();
+  charts.combinedDaily = new Chart(document.getElementById('chart-combined-daily').getContext('2d'), {
+    type: 'bar',
+    data: {
+      labels: days,
+      datasets: [
+        { label: 'Claude', data: days.map(d => dayMap[d].claude), backgroundColor: TOKEN_COLORS.claude, stack: 'provider' },
+        { label: 'Codex', data: days.map(d => dayMap[d].codex), backgroundColor: TOKEN_COLORS.codex, stack: 'provider' }
+      ]
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { labels: { color: '#8892a4', boxWidth: 12 } } },
+      scales: {
+        x: { ticks: { color: '#8892a4', maxTicksLimit: RANGE_TICKS[selectedRange] }, grid: { color: '#2a2d3a' } },
+        y: { ticks: { color: '#8892a4', callback: v => fmt(v) }, grid: { color: '#2a2d3a' } }
+      }
+    }
+  });
+
+  const tokenTotals = { input: 0, output: 0, cache_read: 0, cache_creation: 0 };
+  for (const r of claudeDailyAll) {
+    if (cutoff && r.day < cutoff) continue;
+    tokenTotals.input += r.input || 0;
+    tokenTotals.output += r.output || 0;
+    tokenTotals.cache_read += r.cache_read || 0;
+    tokenTotals.cache_creation += r.cache_creation || 0;
+  }
+  for (const r of codexDailyAll) {
+    if (cutoff && r.day < cutoff) continue;
+    tokenTotals.input += r.input || 0;
+    tokenTotals.output += r.output || 0;
+    tokenTotals.cache_read += r.cache_read || 0;
+  }
+  if (charts.combinedToken) charts.combinedToken.destroy();
+  charts.combinedToken = new Chart(document.getElementById('chart-combined-token').getContext('2d'), {
+    type: 'doughnut',
+    data: {
+      labels: ['Input', 'Output', 'Cache Read', 'Cache Creation'],
+      datasets: [{ data: [tokenTotals.input, tokenTotals.output, tokenTotals.cache_read, tokenTotals.cache_creation], backgroundColor: [TOKEN_COLORS.input, TOKEN_COLORS.output, TOKEN_COLORS.cache_read, TOKEN_COLORS.cache_creation], borderWidth: 2, borderColor: '#1a1d27' }]
+    },
+    options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { position: 'bottom', labels: { color: '#8892a4', boxWidth: 12 } } } }
+  });
+
+  const pmap = {};
+  for (const s of claudeSessions) {
+    if (cutoff && s.last_date < cutoff) continue;
+    if (!pmap[s.project]) pmap[s.project] = { project: s.project, sessions: 0, turns: 0, cost: 0 };
+    pmap[s.project].sessions += 1;
+    pmap[s.project].turns += s.turns || 0;
+    pmap[s.project].cost += calcCost(s.model, s.input, s.output, s.cache_read, s.cache_creation);
+  }
+  for (const s of codexSessions) {
+    if (cutoff && s.last_date < cutoff) continue;
+    if (!pmap[s.project]) pmap[s.project] = { project: s.project, sessions: 0, turns: 0, cost: 0 };
+    pmap[s.project].sessions += 1;
+    pmap[s.project].turns += s.turns || 0;
+    pmap[s.project].cost += codexCost(s.model, s.input, s.cache_read, s.output);
+  }
+  const top = Object.values(pmap).sort((a, b) => b.cost - a.cost).slice(0, 15);
+  document.getElementById('combined-projects-body').innerHTML = top.map(p => `<tr>
+      <td>${esc(p.project)}</td>
+      <td class="num">${fmt(p.sessions)}</td>
+      <td class="num">${fmt(p.turns)}</td>
+      <td class="cost">${fmtCost(p.cost)}</td>
+    </tr>`).join('');
+}
+
 function csvField(val) {
   const s = String(val);
-  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
-    return '"' + s.replace(/"/g, '""') + '"';
-  }
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) return '"' + s.replace(/"/g, '""') + '"';
   return s;
 }
-
 function csvTimestamp() {
   const d = new Date();
-  return d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-' + String(d.getDate()).padStart(2,'0')
-    + '_' + String(d.getHours()).padStart(2,'0') + String(d.getMinutes()).padStart(2,'0');
+  return d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-' + String(d.getDate()).padStart(2,'0') + '_' + String(d.getHours()).padStart(2,'0') + String(d.getMinutes()).padStart(2,'0');
 }
-
 function downloadCSV(reportType, header, rows) {
   const lines = [header.map(csvField).join(',')];
-  for (const row of rows) {
-    lines.push(row.map(csvField).join(','));
-  }
+  for (const row of rows) lines.push(row.map(csvField).join(','));
   const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
   const a = document.createElement('a');
   a.href = URL.createObjectURL(blob);
@@ -1068,25 +1507,17 @@ function downloadCSV(reportType, header, rows) {
   a.click();
   URL.revokeObjectURL(a.href);
 }
-
 function exportSessionsCSV() {
   const header = ['Session', 'Project', 'Last Active', 'Duration (min)', 'Model', 'Turns', 'Input', 'Output', 'Cache Read', 'Cache Creation', 'Est. Cost'];
-  const rows = lastFilteredSessions.map(s => {
-    const cost = calcCost(s.model, s.input, s.output, s.cache_read, s.cache_creation);
-    return [s.session_id, s.project, s.last, s.duration_min, s.model, s.turns, s.input, s.output, s.cache_read, s.cache_creation, cost.toFixed(4)];
-  });
+  const rows = lastFilteredSessions.map(s => [s.session_id, s.project, s.last, s.duration_min, s.model, s.turns, s.input, s.output, s.cache_read, s.cache_creation, calcCost(s.model, s.input, s.output, s.cache_read, s.cache_creation).toFixed(4)]);
   downloadCSV('sessions', header, rows);
 }
-
 function exportProjectsCSV() {
   const header = ['Project', 'Sessions', 'Turns', 'Input', 'Output', 'Cache Read', 'Cache Creation', 'Est. Cost'];
-  const rows = lastByProject.map(p => {
-    return [p.project, p.sessions, p.turns, p.input, p.output, p.cache_read, p.cache_creation, p.cost.toFixed(4)];
-  });
+  const rows = lastByProject.map(p => [p.project, p.sessions, p.turns, p.input, p.output, p.cache_read, p.cache_creation, p.cost.toFixed(4)]);
   downloadCSV('projects', header, rows);
 }
 
-// ── Rescan ────────────────────────────────────────────────────────────────
 async function triggerRescan() {
   const btn = document.getElementById('rescan-btn');
   btn.disabled = true;
@@ -1096,14 +1527,13 @@ async function triggerRescan() {
     const d = await resp.json();
     btn.textContent = '\u21bb Rescan (' + d.new + ' new, ' + d.updated + ' updated)';
     await loadData();
-  } catch(e) {
+  } catch (e) {
     btn.textContent = '\u21bb Rescan (error)';
     console.error(e);
   }
   setTimeout(() => { btn.textContent = '\u21bb Rescan'; btn.disabled = false; }, 3000);
 }
 
-// ── Data loading ───────────────────────────────────────────────────────────
 async function loadData() {
   try {
     const resp = await fetch('/api/data');
@@ -1112,225 +1542,27 @@ async function loadData() {
       document.body.innerHTML = '<div style="padding:40px;color:#f87171">' + esc(d.error) + '</div>';
       return;
     }
-    document.getElementById('meta').textContent = 'Updated: ' + d.generated_at + ' \u00b7 Auto-refresh in 30s';
-
+    document.getElementById('meta').textContent = 'Updated: ' + d.generated_at + ' - Auto-refresh in 30s';
     const isFirstLoad = rawData === null;
     rawData = d;
+    window._data = d;
 
     if (isFirstLoad) {
-      // Restore range from URL, mark active button
       selectedRange = readURLRange();
-      document.querySelectorAll('.range-btn').forEach(btn =>
-        btn.classList.toggle('active', btn.dataset.range === selectedRange)
-      );
-      // Build model filter (reads URL for model selection too)
-      buildFilterUI(d.all_models);
+      document.querySelectorAll('.range-btn').forEach(btn => btn.classList.toggle('active', btn.dataset.range === selectedRange));
+      buildFilterUI(d.all_models || []);
       updateSortIcons();
       updateModelSortIcons();
       updateProjectSortIcons();
+      updateCodexSortIcons();
+      initTabs();
     }
 
+    renderCodexStrip(d.codex_strip || {});
     applyFilter();
-    renderStrip(d);
-    if (currentTab === 'codex') renderCodexTab(d);
-    if (currentTab === 'combined') renderCombinedTab(d);
-    if (isFirstLoad) initTabs();
-  } catch(e) {
+  } catch (e) {
     console.error(e);
   }
-}
-
-// ── Tab switching ──────────────────────────────────────────────────────────
-const TAB_KEY = 'aidash_tab';
-let currentTab = localStorage.getItem(TAB_KEY) || 'claude';
-
-function switchTab(tab) {
-  currentTab = tab;
-  localStorage.setItem(TAB_KEY, tab);
-  document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
-  document.querySelectorAll('.tab-pane').forEach(p => p.classList.remove('active'));
-  const btn = document.getElementById('tab-' + tab);
-  if (btn) btn.classList.add('active');
-  const pane = document.getElementById('pane-' + tab);
-  if (pane) pane.classList.add('active');
-  if (tab === 'codex' && rawData) renderCodexTab(rawData);
-  if (tab === 'combined' && rawData) renderCombinedTab(rawData);
-}
-
-function initTabs() {
-  switchTab(currentTab);
-}
-
-// ── Rate-limit strip ───────────────────────────────────────────────────────
-function gaugeClass(pct) {
-  if (pct == null) return 'low';
-  if (pct >= 80) return 'high';
-  if (pct >= 50) return 'mid';
-  return 'low';
-}
-
-function renderStrip(data) {
-  const cs = data.codex_strip || {};
-  let html = '';
-  if (!cs.state || cs.state === 'unavailable') {
-    html = '<span class="rl-placeholder">unavailable</span>';
-  } else {
-    const fmtGauge = (label, pct, resetStr) => {
-      if (pct == null) return '';
-      const cls = gaugeClass(pct);
-      const p = Math.round(pct);
-      return `<span class="rl-gauge"><span style="color:var(--muted);font-size:11px">${label}</span> `
-           + `<span class="rl-bar"><span class="rl-bar-fill ${cls}" style="width:${p}%"></span></span>`
-           + ` <span>${p}%</span>${resetStr ? ` <span class="rl-fresh">${esc(resetStr)}</span>` : ''}</span>`;
-    };
-    html = fmtGauge('5hr', cs.primary_pct, cs.primary_resets_str)
-         + ' ' + fmtGauge('7d', cs.secondary_pct, cs.secondary_resets_str);
-    if (cs.plan_type) html += ` <span class="rl-chip">${esc(cs.plan_type)}</span>`;
-    if (cs.freshness_s != null) {
-      const fs = cs.freshness_s;
-      const fsStr = fs < 60 ? `${fs}s ago` : `${Math.round(fs/60)}m ago`;
-      html += ` <span class="rl-fresh">${fsStr}</span>`;
-    }
-  }
-  const el = document.getElementById('rl-codex-content');
-  if (el) el.innerHTML = html;
-}
-
-// ── Codex pricing ──────────────────────────────────────────────────────────
-const CODEX_PRICING_JS = {
-  'gpt-5':         {in: 1.25, cached_in: 0.125, out: 10.0},
-  'gpt-5.2-codex': {in: 1.25, cached_in: 0.125, out: 10.0},
-  'gpt-5.3-codex': {in: 1.25, cached_in: 0.125, out: 10.0},
-};
-function codexCost(model, inp, cached, out) {
-  const p = CODEX_PRICING_JS[model] || CODEX_PRICING_JS['gpt-5'];
-  return ((inp - cached) * p.in + cached * p.cached_in + out * p.out) / 1e6;
-}
-
-// ── Codex tab ─────────────────────────────────────────────────────────────
-let codexCharts = {};
-function destroyCodexCharts() {
-  Object.values(codexCharts).forEach(c => { try { c.destroy(); } catch(e) {} });
-  codexCharts = {};
-}
-
-function renderCodexTab(data) {
-  destroyCodexCharts();
-  const sessions = data.codex_sessions || [];
-  const daily = data.codex_daily || [];
-  const cutoff = rangeCutoff(selectedRange);
-  const filtS = sessions.filter(s => !cutoff || s.last_date >= cutoff);
-  const filtD = daily.filter(r => !cutoff || r.day >= cutoff);
-
-  const totalCost = filtS.reduce((sum, s) => sum + codexCost(s.model, s.input, s.cache_read, s.output), 0);
-  const totalTurns = filtS.reduce((sum, s) => sum + (s.turns || 0), 0);
-  document.getElementById('codex-stats-row').innerHTML = `
-    <div class="stat-card"><div class="label">Sessions (${selectedRange})</div><div class="value">${filtS.length}</div></div>
-    <div class="stat-card"><div class="label">Turns</div><div class="value">${fmt(totalTurns)}</div></div>
-    <div class="stat-card"><div class="label">Est. Cost</div><div class="value">${fmtCost(totalCost)}</div></div>
-  `;
-
-  const days = [...new Set(filtD.map(r => r.day))].sort();
-  const models = [...new Set(filtD.map(r => r.model))];
-  const palette = ['#4f8ef7','#d97757','#4ade80','#f59e0b','#a78bfa'];
-  const datasets = models.map((m, i) => ({
-    label: m,
-    data: days.map(d => { const r = filtD.find(x => x.day===d && x.model===m); return r ? r.input + r.output : 0; }),
-    backgroundColor: palette[i % palette.length],
-  }));
-  const chartOpts = { responsive: true, maintainAspectRatio: false,
-    plugins: { legend: { labels: { color: '#8892a4' } } },
-    scales: { x: { stacked: true, ticks: { color: '#8892a4' } }, y: { stacked: true, ticks: { color: '#8892a4' } } } };
-  const dc = document.getElementById('chart-codex-daily');
-  if (dc) codexCharts.daily = new Chart(dc, { type: 'bar', data: { labels: days, datasets }, options: chartOpts });
-
-  const byModel = {};
-  filtD.forEach(r => { byModel[r.model] = (byModel[r.model] || 0) + r.input + r.output; });
-  const mc = document.getElementById('chart-codex-model');
-  if (mc) codexCharts.model = new Chart(mc, {
-    type: 'doughnut',
-    data: { labels: Object.keys(byModel), datasets: [{ data: Object.values(byModel), backgroundColor: palette }] },
-    options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { labels: { color: '#8892a4' } } } }
-  });
-
-  const byProj = {};
-  filtS.forEach(s => { byProj[s.project] = (byProj[s.project] || 0) + s.input + s.output; });
-  const top5 = Object.entries(byProj).sort((a,b) => b[1]-a[1]).slice(0,5);
-  const pc = document.getElementById('chart-codex-project');
-  if (pc) codexCharts.project = new Chart(pc, {
-    type: 'bar',
-    data: { labels: top5.map(([p]) => p.length > 22 ? '…'+p.slice(-21) : p), datasets: [{ data: top5.map(([,v]) => v), backgroundColor: '#4f8ef7', label: 'Tokens' }] },
-    options: { indexAxis: 'y', responsive: true, maintainAspectRatio: false, plugins: { legend: { display: false } }, scales: { x: { ticks: { color: '#8892a4' } }, y: { ticks: { color: '#8892a4' } } } }
-  });
-
-  const modelCosts = {};
-  filtS.forEach(s => {
-    if (!modelCosts[s.model]) modelCosts[s.model] = {turns:0, input:0, output:0, cache_read:0, cost:0};
-    const mc2 = modelCosts[s.model];
-    mc2.turns += s.turns||0; mc2.input += s.input||0; mc2.output += s.output||0;
-    mc2.cache_read += s.cache_read||0;
-    mc2.cost += codexCost(s.model, s.input||0, s.cache_read||0, s.output||0);
-  });
-  document.getElementById('codex-model-cost-body').innerHTML = Object.entries(modelCosts)
-    .sort((a,b) => b[1].cost - a[1].cost)
-    .map(([m, mc2]) => `<tr><td><span class="model-tag">${esc(m)}</span></td><td class="num">${fmt(mc2.turns)}</td><td class="num">${fmt(mc2.input)}</td><td class="num">${fmt(mc2.output)}</td><td class="num">${fmt(mc2.cache_read)}</td><td class="cost">${fmtCost(mc2.cost)}</td></tr>`)
-    .join('');
-
-  document.getElementById('codex-sessions-body').innerHTML = filtS.slice(0, 50)
-    .map(s => `<tr><td>${esc(s.session_id)}</td><td>${esc(s.project)}</td><td>${esc(s.last)}</td><td><span class="model-tag">${esc(s.model)}</span></td><td class="num">${s.turns||0}</td><td class="num">${fmt(s.input||0)}</td><td class="num">${fmt(s.output||0)}</td><td class="cost">${fmtCost(codexCost(s.model, s.input||0, s.cache_read||0, s.output||0))}</td></tr>`)
-    .join('');
-}
-
-// ── Combined tab ───────────────────────────────────────────────────────────
-let combinedCharts = {};
-function destroyCombinedCharts() {
-  Object.values(combinedCharts).forEach(c => { try { c.destroy(); } catch(e) {} });
-  combinedCharts = {};
-}
-
-function renderCombinedTab(data) {
-  destroyCombinedCharts();
-  const combined = data.combined_daily || [];
-  const cutoff = rangeCutoff(selectedRange);
-  const filt = combined.filter(r => !cutoff || r.day >= cutoff);
-
-  const totals = {};
-  filt.forEach(r => {
-    const p = r.provider || 'claude';
-    if (!totals[p]) totals[p] = {tokens: 0, turns: 0};
-    totals[p].tokens += (r.input||0) + (r.output||0);
-    totals[p].turns += r.turns||0;
-  });
-  const clt = totals.claude || {tokens:0, turns:0};
-  const cxt = totals.codex  || {tokens:0, turns:0};
-
-  document.getElementById('combined-stats-row').innerHTML = `
-    <div class="stat-card"><div class="label">Claude Tokens (${selectedRange})</div><div class="value">${fmt(clt.tokens)}</div></div>
-    <div class="stat-card"><div class="label">Codex Tokens (${selectedRange})</div><div class="value">${fmt(cxt.tokens)}</div></div>
-    <div class="stat-card"><div class="label">Total Turns</div><div class="value">${fmt(clt.turns + cxt.turns)}</div></div>
-  `;
-
-  const days = [...new Set(filt.map(r => r.day))].sort();
-  const claudeData = days.map(d => { const r = filt.find(x => x.day===d && x.provider==='claude'); return r ? (r.input||0)+(r.output||0) : 0; });
-  const codexData  = days.map(d => { const r = filt.find(x => x.day===d && x.provider==='codex');  return r ? (r.input||0)+(r.output||0) : 0; });
-  const dc2 = document.getElementById('chart-combined-daily');
-  if (dc2) combinedCharts.daily = new Chart(dc2, {
-    type: 'bar',
-    data: { labels: days, datasets: [
-      { label: 'Claude', data: claudeData, backgroundColor: '#d97757' },
-      { label: 'Codex',  data: codexData,  backgroundColor: '#4f8ef7' },
-    ]},
-    options: { responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { labels: { color: '#8892a4' } } },
-      scales: { x: { stacked: true, ticks: { color: '#8892a4' } }, y: { stacked: true, ticks: { color: '#8892a4' } } } }
-  });
-
-  const dn = document.getElementById('chart-combined-donut');
-  if (dn) combinedCharts.donut = new Chart(dn, {
-    type: 'doughnut',
-    data: { labels: ['Claude', 'Codex'], datasets: [{ data: [clt.tokens, cxt.tokens], backgroundColor: ['#d97757','#4f8ef7'] }] },
-    options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { labels: { color: '#8892a4' } } } }
-  });
 }
 
 loadData();
@@ -1382,6 +1614,7 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self.send_response(404)
             self.end_headers()
 
+
 def serve(host=None, port=None):
     host = host or os.environ.get("HOST", "localhost")
     port = port or int(os.environ.get("PORT", "9123"))
@@ -1396,5 +1629,5 @@ def serve(host=None, port=None):
 
 if __name__ == "__main__":
     import sys
-    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
-    serve(port)
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 9123
+    serve(port=port)

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,5 +1,5 @@
 """
-dashboard.py - Local web dashboard served on localhost:8080.
+dashboard.py - Local web dashboard served on localhost:9123.
 """
 
 import json
@@ -10,6 +10,92 @@ from pathlib import Path
 from datetime import datetime
 
 DB_PATH = Path.home() / ".claude" / "usage.db"
+
+
+def get_codex_status(db_path=DB_PATH):
+    """Get Codex rate limit status, merging JSONL data and usage-monitor state."""
+    import time
+
+    result = {"state": "unavailable"}
+    best_ts = 0
+
+    # Source 1: codex_rate_limits table (from JSONL scanner)
+    if db_path.exists():
+        try:
+            conn = sqlite3.connect(db_path)
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT * FROM codex_rate_limits WHERE id=1").fetchone()
+            conn.close()
+            if row:
+                best_ts = row["scraped_at"] or 0
+                result = {
+                    "state": "green",
+                    "primary_pct": row["primary_pct"],
+                    "primary_resets_at": row["primary_resets_at"],
+                    "secondary_pct": row["secondary_pct"],
+                    "secondary_resets_at": row["secondary_resets_at"],
+                    "plan_type": (row["plan_type"] or "").title() or None,
+                    "credits_has": bool(row["credits_has"]),
+                    "freshness_s": int(time.time()) - best_ts,
+                    "auth_ok": True,
+                    "source": "jsonl",
+                }
+        except Exception:
+            pass
+
+    # Source 2: usage-monitor-state.json (from wham poll)
+    state_file = Path.home() / ".cc-agents" / "scripts" / "usage-monitor-state.json"
+    if state_file.exists():
+        try:
+            with open(state_file) as f:
+                mon = json.load(f)
+            # usage-monitor stores codex data under codex_five_hour / codex_seven_day
+            mon_ts_str = mon.get("timestamp") or mon.get("ts") or ""
+            mon_ts = 0
+            if mon_ts_str:
+                try:
+                    dt = datetime.fromisoformat(mon_ts_str.replace("Z", "+00:00"))
+                    mon_ts = int(dt.timestamp())
+                except Exception:
+                    pass
+            if mon_ts > best_ts:
+                best_ts = mon_ts
+                fh = mon.get("codex_five_hour", {})
+                sd = mon.get("codex_seven_day", {})
+                result = {
+                    "state": "green",
+                    "primary_pct": fh.get("pct"),
+                    "primary_resets_at": None,
+                    "secondary_pct": sd.get("pct"),
+                    "secondary_resets_at": None,
+                    "plan_type": None,
+                    "credits_has": False,
+                    "freshness_s": int(time.time()) - mon_ts,
+                    "auth_ok": True,
+                    "source": "monitor",
+                }
+        except Exception:
+            pass
+
+    # Format reset times as human strings
+    def _fmt_resets(ts):
+        if not ts:
+            return None
+        import time as time_mod
+        delta = ts - int(time_mod.time())
+        if delta <= 0:
+            return "Resets soon"
+        h = delta // 3600
+        m = (delta % 3600) // 60
+        if h > 0:
+            return f"in {h}h {m}m"
+        return f"in {m}m"
+
+    if "primary_resets_at" in result:
+        result["primary_resets_str"] = _fmt_resets(result.get("primary_resets_at"))
+        result["secondary_resets_str"] = _fmt_resets(result.get("secondary_resets_at"))
+
+    return result
 
 
 def get_dashboard_data(db_path=DB_PATH):
@@ -23,6 +109,7 @@ def get_dashboard_data(db_path=DB_PATH):
     model_rows = conn.execute("""
         SELECT COALESCE(model, 'unknown') as model
         FROM turns
+        WHERE COALESCE(provider, 'claude') = 'claude'
         GROUP BY model
         ORDER BY SUM(input_tokens + output_tokens) DESC
     """).fetchall()
@@ -39,6 +126,7 @@ def get_dashboard_data(db_path=DB_PATH):
             SUM(cache_creation_tokens) as cache_creation,
             COUNT(*)                   as turns
         FROM turns
+        WHERE COALESCE(provider, 'claude') = 'claude'
         GROUP BY day, model
         ORDER BY day, model
     """).fetchall()
@@ -60,6 +148,7 @@ def get_dashboard_data(db_path=DB_PATH):
             total_input_tokens, total_output_tokens,
             total_cache_read, total_cache_creation, model, turn_count
         FROM sessions
+        WHERE COALESCE(provider, 'claude') = 'claude'
         ORDER BY last_timestamp DESC
     """).fetchall()
 
@@ -87,11 +176,85 @@ def get_dashboard_data(db_path=DB_PATH):
 
     conn.close()
 
+    # --- Codex data ---
+    codex_daily_rows = []
+    codex_sessions_all = []
+    combined_daily_rows = []
+
+    if db_path.exists():
+        conn2 = sqlite3.connect(db_path)
+        conn2.row_factory = sqlite3.Row
+
+        # Codex daily
+        cdrows = conn2.execute("""
+            SELECT substr(timestamp,1,10) as day,
+                   COALESCE(model,'gpt-5') as model,
+                   SUM(input_tokens) as input, SUM(output_tokens) as output,
+                   SUM(cache_read_tokens) as cache_read, COUNT(*) as turns
+            FROM turns WHERE provider='codex'
+            GROUP BY day, model ORDER BY day, model
+        """).fetchall()
+        codex_daily_rows = [{
+            "day": r["day"], "model": r["model"],
+            "input": r["input"] or 0, "output": r["output"] or 0,
+            "cache_read": r["cache_read"] or 0, "turns": r["turns"] or 0,
+        } for r in cdrows]
+
+        # Codex sessions
+        csrows = conn2.execute("""
+            SELECT session_id, project_name, first_timestamp, last_timestamp,
+                   total_input_tokens, total_output_tokens,
+                   total_cache_read, model, turn_count
+            FROM sessions WHERE provider='codex'
+            ORDER BY last_timestamp DESC
+        """).fetchall()
+        for r in csrows:
+            try:
+                t1 = datetime.fromisoformat((r["first_timestamp"] or "").replace("Z","+00:00"))
+                t2 = datetime.fromisoformat((r["last_timestamp"] or "").replace("Z","+00:00"))
+                dur = round((t2-t1).total_seconds()/60, 1)
+            except Exception:
+                dur = 0
+            codex_sessions_all.append({
+                "session_id": (r["session_id"] or "")[:8],
+                "project": r["project_name"] or "unknown",
+                "last": (r["last_timestamp"] or "")[:16].replace("T"," "),
+                "last_date": (r["last_timestamp"] or "")[:10],
+                "duration_min": dur,
+                "model": r["model"] or "gpt-5",
+                "turns": r["turn_count"] or 0,
+                "input": r["total_input_tokens"] or 0,
+                "output": r["total_output_tokens"] or 0,
+                "cache_read": r["total_cache_read"] or 0,
+            })
+
+        # Combined daily (both providers)
+        combrows = conn2.execute("""
+            SELECT substr(timestamp,1,10) as day,
+                   COALESCE(provider,'claude') as provider,
+                   SUM(input_tokens) as input, SUM(output_tokens) as output,
+                   SUM(cache_read_tokens) as cache_read, COUNT(*) as turns
+            FROM turns GROUP BY day, provider ORDER BY day, provider
+        """).fetchall()
+        combined_daily_rows = [{
+            "day": r["day"], "provider": r["provider"],
+            "input": r["input"] or 0, "output": r["output"] or 0,
+            "cache_read": r["cache_read"] or 0, "turns": r["turns"] or 0,
+        } for r in combrows]
+
+        conn2.close()
+
+    codex_strip = get_codex_status(db_path)
+
     return {
         "all_models":     all_models,
         "daily_by_model": daily_by_model,
         "sessions_all":   sessions_all,
         "generated_at":   datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "codex_strip":    codex_strip,
+        "codex_daily":    codex_daily_rows,
+        "codex_sessions": codex_sessions_all,
+        "combined_daily": combined_daily_rows,
     }
 
 
@@ -100,7 +263,7 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Claude Code Usage Dashboard</title>
+<title>AI Usage Dashboard</title>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <style>
   :root {
@@ -181,15 +344,57 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
   .footer-content a:hover { text-decoration: underline; }
 
   @media (max-width: 768px) { .charts-grid { grid-template-columns: 1fr; } .chart-card.wide { grid-column: 1; } }
+
+  /* Tab bar */
+  .tab-bar { background: var(--card); border-bottom: 1px solid var(--border); padding: 0 24px; display: flex; }
+  .tab-btn { padding: 12px 20px; background: transparent; border: none; border-bottom: 2px solid transparent; color: var(--muted); font-size: 13px; font-weight: 500; cursor: pointer; transition: color 0.15s, border-color 0.15s; }
+  .tab-btn:hover { color: var(--text); }
+  .tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
+  .tab-pane { display: none; }
+  .tab-pane.active { display: block; }
+
+  /* Rate-limit strip */
+  .rl-strip { background: var(--card); border-bottom: 1px solid var(--border); padding: 8px 24px; display: flex; gap: 24px; align-items: center; flex-wrap: wrap; }
+  .rl-col { display: flex; align-items: center; gap: 10px; }
+  .rl-label { font-size: 11px; font-weight: 600; text-transform: uppercase; color: var(--muted); white-space: nowrap; }
+  .rl-gauge { display: flex; align-items: center; gap: 5px; font-size: 12px; }
+  .rl-bar { width: 56px; height: 5px; background: var(--border); border-radius: 3px; overflow: hidden; display: inline-block; vertical-align: middle; }
+  .rl-bar-fill { height: 100%; border-radius: 3px; }
+  .rl-bar-fill.low  { background: var(--green); }
+  .rl-bar-fill.mid  { background: #f59e0b; }
+  .rl-bar-fill.high { background: #ef4444; }
+  .rl-chip { font-size: 11px; padding: 2px 7px; border-radius: 10px; border: 1px solid var(--border); color: var(--muted); }
+  .rl-sep { width: 1px; height: 28px; background: var(--border); flex-shrink: 0; }
+  .rl-placeholder { color: var(--muted); font-size: 12px; font-style: italic; }
+  .rl-fresh { color: var(--muted); font-size: 11px; }
 </style>
 </head>
 <body>
 <header>
-  <h1>Claude Code Usage Dashboard</h1>
+  <h1>AI Usage Dashboard</h1>
   <div class="meta" id="meta">Loading...</div>
   <button id="rescan-btn" onclick="triggerRescan()" title="Rebuild the database from scratch by re-scanning all JSONL files. Use if data looks stale or costs seem wrong.">&#x21bb; Rescan</button>
 </header>
 
+<div class="tab-bar">
+  <button class="tab-btn" id="tab-claude" onclick="switchTab('claude')">Claude</button>
+  <button class="tab-btn" id="tab-codex" onclick="switchTab('codex')">Codex</button>
+  <button class="tab-btn" id="tab-combined" onclick="switchTab('combined')">Combined</button>
+</div>
+
+<div class="rl-strip">
+  <div class="rl-col">
+    <span class="rl-label">Codex</span>
+    <span id="rl-codex-content"><span class="rl-placeholder">loading…</span></span>
+  </div>
+  <div class="rl-sep"></div>
+  <div class="rl-col">
+    <span class="rl-label">Gemini</span>
+    <span class="rl-placeholder">not configured — run <code>gemini auth login</code></span>
+  </div>
+</div>
+
+<div class="tab-pane" id="pane-claude">
 <div id="filter-bar">
   <div class="filter-label">Models</div>
   <div id="model-checkboxes"></div>
@@ -268,6 +473,55 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
     </table>
   </div>
 </div>
+</div><!-- end pane-claude -->
+
+<div class="tab-pane" id="pane-codex">
+  <div class="container">
+    <div class="stats-row" id="codex-stats-row"></div>
+    <div class="charts-grid">
+      <div class="chart-card wide">
+        <h2>Daily Codex Usage</h2>
+        <div class="chart-wrap tall"><canvas id="chart-codex-daily"></canvas></div>
+      </div>
+      <div class="chart-card">
+        <h2>By Model</h2>
+        <div class="chart-wrap"><canvas id="chart-codex-model"></canvas></div>
+      </div>
+      <div class="chart-card">
+        <h2>Top Projects</h2>
+        <div class="chart-wrap"><canvas id="chart-codex-project"></canvas></div>
+      </div>
+    </div>
+    <div class="table-card">
+      <div class="section-title">Cost by Model</div>
+      <table><thead><tr>
+        <th>Model</th><th>Turns</th><th>Input</th><th>Output</th><th>Cache Read</th><th>Est. Cost</th>
+      </tr></thead><tbody id="codex-model-cost-body"></tbody></table>
+    </div>
+    <div class="table-card">
+      <div class="section-title">Sessions</div>
+      <table><thead><tr>
+        <th>Session</th><th>Project</th><th>Last Active</th><th>Model</th><th>Turns</th><th>Input</th><th>Output</th><th>Est. Cost</th>
+      </tr></thead><tbody id="codex-sessions-body"></tbody></table>
+    </div>
+  </div>
+</div><!-- end pane-codex -->
+
+<div class="tab-pane" id="pane-combined">
+  <div class="container">
+    <div class="stats-row" id="combined-stats-row"></div>
+    <div class="charts-grid">
+      <div class="chart-card wide">
+        <h2>Daily Usage by Provider</h2>
+        <div class="chart-wrap tall"><canvas id="chart-combined-daily"></canvas></div>
+      </div>
+      <div class="chart-card">
+        <h2>Token Share by Provider</h2>
+        <div class="chart-wrap"><canvas id="chart-combined-donut"></canvas></div>
+      </div>
+    </div>
+  </div>
+</div><!-- end pane-combined -->
 
 <footer>
   <div class="footer-content">
@@ -877,9 +1131,206 @@ async function loadData() {
     }
 
     applyFilter();
+    renderStrip(d);
+    if (currentTab === 'codex') renderCodexTab(d);
+    if (currentTab === 'combined') renderCombinedTab(d);
+    if (isFirstLoad) initTabs();
   } catch(e) {
     console.error(e);
   }
+}
+
+// ── Tab switching ──────────────────────────────────────────────────────────
+const TAB_KEY = 'aidash_tab';
+let currentTab = localStorage.getItem(TAB_KEY) || 'claude';
+
+function switchTab(tab) {
+  currentTab = tab;
+  localStorage.setItem(TAB_KEY, tab);
+  document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+  document.querySelectorAll('.tab-pane').forEach(p => p.classList.remove('active'));
+  const btn = document.getElementById('tab-' + tab);
+  if (btn) btn.classList.add('active');
+  const pane = document.getElementById('pane-' + tab);
+  if (pane) pane.classList.add('active');
+  if (tab === 'codex' && rawData) renderCodexTab(rawData);
+  if (tab === 'combined' && rawData) renderCombinedTab(rawData);
+}
+
+function initTabs() {
+  switchTab(currentTab);
+}
+
+// ── Rate-limit strip ───────────────────────────────────────────────────────
+function gaugeClass(pct) {
+  if (pct == null) return 'low';
+  if (pct >= 80) return 'high';
+  if (pct >= 50) return 'mid';
+  return 'low';
+}
+
+function renderStrip(data) {
+  const cs = data.codex_strip || {};
+  let html = '';
+  if (!cs.state || cs.state === 'unavailable') {
+    html = '<span class="rl-placeholder">unavailable</span>';
+  } else {
+    const fmtGauge = (label, pct, resetStr) => {
+      if (pct == null) return '';
+      const cls = gaugeClass(pct);
+      const p = Math.round(pct);
+      return `<span class="rl-gauge"><span style="color:var(--muted);font-size:11px">${label}</span> `
+           + `<span class="rl-bar"><span class="rl-bar-fill ${cls}" style="width:${p}%"></span></span>`
+           + ` <span>${p}%</span>${resetStr ? ` <span class="rl-fresh">${esc(resetStr)}</span>` : ''}</span>`;
+    };
+    html = fmtGauge('5hr', cs.primary_pct, cs.primary_resets_str)
+         + ' ' + fmtGauge('7d', cs.secondary_pct, cs.secondary_resets_str);
+    if (cs.plan_type) html += ` <span class="rl-chip">${esc(cs.plan_type)}</span>`;
+    if (cs.freshness_s != null) {
+      const fs = cs.freshness_s;
+      const fsStr = fs < 60 ? `${fs}s ago` : `${Math.round(fs/60)}m ago`;
+      html += ` <span class="rl-fresh">${fsStr}</span>`;
+    }
+  }
+  const el = document.getElementById('rl-codex-content');
+  if (el) el.innerHTML = html;
+}
+
+// ── Codex pricing ──────────────────────────────────────────────────────────
+const CODEX_PRICING_JS = {
+  'gpt-5':         {in: 1.25, cached_in: 0.125, out: 10.0},
+  'gpt-5.2-codex': {in: 1.25, cached_in: 0.125, out: 10.0},
+  'gpt-5.3-codex': {in: 1.25, cached_in: 0.125, out: 10.0},
+};
+function codexCost(model, inp, cached, out) {
+  const p = CODEX_PRICING_JS[model] || CODEX_PRICING_JS['gpt-5'];
+  return ((inp - cached) * p.in + cached * p.cached_in + out * p.out) / 1e6;
+}
+
+// ── Codex tab ─────────────────────────────────────────────────────────────
+let codexCharts = {};
+function destroyCodexCharts() {
+  Object.values(codexCharts).forEach(c => { try { c.destroy(); } catch(e) {} });
+  codexCharts = {};
+}
+
+function renderCodexTab(data) {
+  destroyCodexCharts();
+  const sessions = data.codex_sessions || [];
+  const daily = data.codex_daily || [];
+  const cutoff = rangeCutoff(selectedRange);
+  const filtS = sessions.filter(s => !cutoff || s.last_date >= cutoff);
+  const filtD = daily.filter(r => !cutoff || r.day >= cutoff);
+
+  const totalCost = filtS.reduce((sum, s) => sum + codexCost(s.model, s.input, s.cache_read, s.output), 0);
+  const totalTurns = filtS.reduce((sum, s) => sum + (s.turns || 0), 0);
+  document.getElementById('codex-stats-row').innerHTML = `
+    <div class="stat-card"><div class="label">Sessions (${selectedRange})</div><div class="value">${filtS.length}</div></div>
+    <div class="stat-card"><div class="label">Turns</div><div class="value">${fmt(totalTurns)}</div></div>
+    <div class="stat-card"><div class="label">Est. Cost</div><div class="value">${fmtCost(totalCost)}</div></div>
+  `;
+
+  const days = [...new Set(filtD.map(r => r.day))].sort();
+  const models = [...new Set(filtD.map(r => r.model))];
+  const palette = ['#4f8ef7','#d97757','#4ade80','#f59e0b','#a78bfa'];
+  const datasets = models.map((m, i) => ({
+    label: m,
+    data: days.map(d => { const r = filtD.find(x => x.day===d && x.model===m); return r ? r.input + r.output : 0; }),
+    backgroundColor: palette[i % palette.length],
+  }));
+  const chartOpts = { responsive: true, maintainAspectRatio: false,
+    plugins: { legend: { labels: { color: '#8892a4' } } },
+    scales: { x: { stacked: true, ticks: { color: '#8892a4' } }, y: { stacked: true, ticks: { color: '#8892a4' } } } };
+  const dc = document.getElementById('chart-codex-daily');
+  if (dc) codexCharts.daily = new Chart(dc, { type: 'bar', data: { labels: days, datasets }, options: chartOpts });
+
+  const byModel = {};
+  filtD.forEach(r => { byModel[r.model] = (byModel[r.model] || 0) + r.input + r.output; });
+  const mc = document.getElementById('chart-codex-model');
+  if (mc) codexCharts.model = new Chart(mc, {
+    type: 'doughnut',
+    data: { labels: Object.keys(byModel), datasets: [{ data: Object.values(byModel), backgroundColor: palette }] },
+    options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { labels: { color: '#8892a4' } } } }
+  });
+
+  const byProj = {};
+  filtS.forEach(s => { byProj[s.project] = (byProj[s.project] || 0) + s.input + s.output; });
+  const top5 = Object.entries(byProj).sort((a,b) => b[1]-a[1]).slice(0,5);
+  const pc = document.getElementById('chart-codex-project');
+  if (pc) codexCharts.project = new Chart(pc, {
+    type: 'bar',
+    data: { labels: top5.map(([p]) => p.length > 22 ? '…'+p.slice(-21) : p), datasets: [{ data: top5.map(([,v]) => v), backgroundColor: '#4f8ef7', label: 'Tokens' }] },
+    options: { indexAxis: 'y', responsive: true, maintainAspectRatio: false, plugins: { legend: { display: false } }, scales: { x: { ticks: { color: '#8892a4' } }, y: { ticks: { color: '#8892a4' } } } }
+  });
+
+  const modelCosts = {};
+  filtS.forEach(s => {
+    if (!modelCosts[s.model]) modelCosts[s.model] = {turns:0, input:0, output:0, cache_read:0, cost:0};
+    const mc2 = modelCosts[s.model];
+    mc2.turns += s.turns||0; mc2.input += s.input||0; mc2.output += s.output||0;
+    mc2.cache_read += s.cache_read||0;
+    mc2.cost += codexCost(s.model, s.input||0, s.cache_read||0, s.output||0);
+  });
+  document.getElementById('codex-model-cost-body').innerHTML = Object.entries(modelCosts)
+    .sort((a,b) => b[1].cost - a[1].cost)
+    .map(([m, mc2]) => `<tr><td><span class="model-tag">${esc(m)}</span></td><td class="num">${fmt(mc2.turns)}</td><td class="num">${fmt(mc2.input)}</td><td class="num">${fmt(mc2.output)}</td><td class="num">${fmt(mc2.cache_read)}</td><td class="cost">${fmtCost(mc2.cost)}</td></tr>`)
+    .join('');
+
+  document.getElementById('codex-sessions-body').innerHTML = filtS.slice(0, 50)
+    .map(s => `<tr><td>${esc(s.session_id)}</td><td>${esc(s.project)}</td><td>${esc(s.last)}</td><td><span class="model-tag">${esc(s.model)}</span></td><td class="num">${s.turns||0}</td><td class="num">${fmt(s.input||0)}</td><td class="num">${fmt(s.output||0)}</td><td class="cost">${fmtCost(codexCost(s.model, s.input||0, s.cache_read||0, s.output||0))}</td></tr>`)
+    .join('');
+}
+
+// ── Combined tab ───────────────────────────────────────────────────────────
+let combinedCharts = {};
+function destroyCombinedCharts() {
+  Object.values(combinedCharts).forEach(c => { try { c.destroy(); } catch(e) {} });
+  combinedCharts = {};
+}
+
+function renderCombinedTab(data) {
+  destroyCombinedCharts();
+  const combined = data.combined_daily || [];
+  const cutoff = rangeCutoff(selectedRange);
+  const filt = combined.filter(r => !cutoff || r.day >= cutoff);
+
+  const totals = {};
+  filt.forEach(r => {
+    const p = r.provider || 'claude';
+    if (!totals[p]) totals[p] = {tokens: 0, turns: 0};
+    totals[p].tokens += (r.input||0) + (r.output||0);
+    totals[p].turns += r.turns||0;
+  });
+  const clt = totals.claude || {tokens:0, turns:0};
+  const cxt = totals.codex  || {tokens:0, turns:0};
+
+  document.getElementById('combined-stats-row').innerHTML = `
+    <div class="stat-card"><div class="label">Claude Tokens (${selectedRange})</div><div class="value">${fmt(clt.tokens)}</div></div>
+    <div class="stat-card"><div class="label">Codex Tokens (${selectedRange})</div><div class="value">${fmt(cxt.tokens)}</div></div>
+    <div class="stat-card"><div class="label">Total Turns</div><div class="value">${fmt(clt.turns + cxt.turns)}</div></div>
+  `;
+
+  const days = [...new Set(filt.map(r => r.day))].sort();
+  const claudeData = days.map(d => { const r = filt.find(x => x.day===d && x.provider==='claude'); return r ? (r.input||0)+(r.output||0) : 0; });
+  const codexData  = days.map(d => { const r = filt.find(x => x.day===d && x.provider==='codex');  return r ? (r.input||0)+(r.output||0) : 0; });
+  const dc2 = document.getElementById('chart-combined-daily');
+  if (dc2) combinedCharts.daily = new Chart(dc2, {
+    type: 'bar',
+    data: { labels: days, datasets: [
+      { label: 'Claude', data: claudeData, backgroundColor: '#d97757' },
+      { label: 'Codex',  data: codexData,  backgroundColor: '#4f8ef7' },
+    ]},
+    options: { responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { labels: { color: '#8892a4' } } },
+      scales: { x: { stacked: true, ticks: { color: '#8892a4' } }, y: { stacked: true, ticks: { color: '#8892a4' } } } }
+  });
+
+  const dn = document.getElementById('chart-combined-donut');
+  if (dn) combinedCharts.donut = new Chart(dn, {
+    type: 'doughnut',
+    data: { labels: ['Claude', 'Codex'], datasets: [{ data: [clt.tokens, cxt.tokens], backgroundColor: ['#d97757','#4f8ef7'] }] },
+    options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { labels: { color: '#8892a4' } } } }
+  });
 }
 
 loadData();
@@ -931,10 +1382,9 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self.send_response(404)
             self.end_headers()
 
-
 def serve(host=None, port=None):
     host = host or os.environ.get("HOST", "localhost")
-    port = port or int(os.environ.get("PORT", "8080"))
+    port = port or int(os.environ.get("PORT", "9123"))
     server = HTTPServer((host, port), DashboardHandler)
     print(f"Dashboard running at http://{host}:{port}")
     print("Press Ctrl+C to stop.")
@@ -945,4 +1395,6 @@ def serve(host=None, port=None):
 
 
 if __name__ == "__main__":
-    serve()
+    import sys
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
+    serve(port)

--- a/scanner.py
+++ b/scanner.py
@@ -73,7 +73,6 @@ def init_db(conn):
         CREATE INDEX IF NOT EXISTS idx_turns_session ON turns(session_id);
         CREATE INDEX IF NOT EXISTS idx_turns_timestamp ON turns(timestamp);
         CREATE INDEX IF NOT EXISTS idx_sessions_first ON sessions(first_timestamp);
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_turns_dedup ON turns(session_id, timestamp, provider);
     """)
     # PR 1 migrations — idempotent ALTER TABLE + new table
     try:
@@ -86,6 +85,10 @@ def init_db(conn):
         pass
     try:
         conn.execute("ALTER TABLE processed_files ADD COLUMN provider TEXT DEFAULT 'claude'")
+    except Exception:
+        pass
+    try:
+        conn.execute("DROP INDEX IF EXISTS idx_turns_dedup")
     except Exception:
         pass
 

--- a/scanner.py
+++ b/scanner.py
@@ -12,6 +12,19 @@ from datetime import datetime, timezone
 PROJECTS_DIR = Path.home() / ".claude" / "projects"
 XCODE_PROJECTS_DIR = Path.home() / "Library" / "Developer" / "Xcode" / "CodingAssistant" / "ClaudeAgentConfig" / "projects"
 DB_PATH = Path.home() / ".claude" / "usage.db"
+
+CODEX_SESSIONS_DIR = Path.home() / ".codex" / "sessions"
+
+CODEX_PRICING = {
+    "gpt-5":         {"in": 1.25, "cached_in": 0.125, "out": 10.0},
+    "gpt-5.2-codex": {"in": 1.25, "cached_in": 0.125, "out": 10.0},
+    "gpt-5.3-codex": {"in": 1.25, "cached_in": 0.125, "out": 10.0},
+}
+CODEX_MODEL_ALIASES = {
+    "gpt-5-codex":   "gpt-5",
+    "gpt-5.3-codex": "gpt-5.2-codex",
+}
+
 DEFAULT_PROJECTS_DIRS = [PROJECTS_DIR, XCODE_PROJECTS_DIR]
 
 
@@ -60,6 +73,37 @@ def init_db(conn):
         CREATE INDEX IF NOT EXISTS idx_turns_session ON turns(session_id);
         CREATE INDEX IF NOT EXISTS idx_turns_timestamp ON turns(timestamp);
         CREATE INDEX IF NOT EXISTS idx_sessions_first ON sessions(first_timestamp);
+    """)
+    # PR 1 migrations — idempotent ALTER TABLE + new table
+    try:
+        conn.execute("ALTER TABLE sessions ADD COLUMN provider TEXT DEFAULT 'claude'")
+    except Exception:
+        pass
+    try:
+        conn.execute("ALTER TABLE turns ADD COLUMN provider TEXT DEFAULT 'claude'")
+    except Exception:
+        pass
+    try:
+        conn.execute("ALTER TABLE processed_files ADD COLUMN provider TEXT DEFAULT 'claude'")
+    except Exception:
+        pass
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS codex_rate_limits (
+            id                  INTEGER PRIMARY KEY CHECK (id = 1),
+            scraped_at          INTEGER NOT NULL,
+            primary_pct         REAL,
+            primary_window      INTEGER,
+            primary_resets_at   INTEGER,
+            secondary_pct       REAL,
+            secondary_window    INTEGER,
+            secondary_resets_at INTEGER,
+            plan_type           TEXT,
+            credits_has         INTEGER,
+            credits_balance     REAL,
+            source_file         TEXT,
+            source_ts           INTEGER
+        )
     """)
     # Add message_id column if upgrading from older schema
     try:
@@ -279,6 +323,293 @@ def insert_turns(conn, turns):
          t["tool_name"], t["cwd"], t.get("message_id", ""))
         for t in turns
     ])
+
+
+def scan_codex(db_path=DB_PATH, verbose=True):
+    """Scan Codex JSONL session files and store data in SQLite."""
+    conn = get_db(db_path)
+    init_db(conn)
+
+    # Find all rollout-*.jsonl files under ~/.codex/sessions/
+    jsonl_files = glob.glob(str(CODEX_SESSIONS_DIR / "**" / "rollout-*.jsonl"), recursive=True)
+    jsonl_files.sort()
+
+    if verbose:
+        print(f"Found {len(jsonl_files)} Codex session files")
+
+    new_files = 0
+    updated_files = 0
+    skipped_files = 0
+    total_turns = 0
+    total_sessions = set()
+    latest_rate_limits = None   # (timestamp_unix, rate_limits_dict, source_file)
+
+    for filepath in jsonl_files:
+        try:
+            mtime = os.path.getmtime(filepath)
+        except OSError:
+            continue
+
+        row = conn.execute(
+            "SELECT mtime, lines FROM processed_files WHERE path = ?",
+            (filepath,)
+        ).fetchone()
+
+        if row and abs(row["mtime"] - mtime) < 0.01:
+            skipped_files += 1
+            continue
+
+        is_new = row is None
+        if verbose:
+            status = "NEW" if is_new else "UPD"
+            print(f"  [{status}] {filepath}")
+
+        # Parse the JSONL file
+        sessions = {}   # session_id -> dict
+        turns = []
+        prev_totals = {}  # session_id -> last total_token_usage
+        last_model = None
+
+        try:
+            with open(filepath, encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    rtype = record.get("type", "")
+
+                    # Session metadata
+                    if rtype == "session_meta":
+                        sid = record.get("id")
+                        if sid:
+                            ts_str = record.get("timestamp", "")
+                            cwd = record.get("cwd", "")
+                            sessions.setdefault(sid, {
+                                "session_id": sid,
+                                "project_name": project_name_from_cwd(cwd),
+                                "first_timestamp": ts_str,
+                                "last_timestamp": ts_str,
+                                "git_branch": "",
+                                "model": None,
+                                "provider": "codex",
+                            })
+                        continue
+
+                    # Track model from turn_context
+                    if rtype == "turn_context":
+                        m = (record.get("model") or
+                             record.get("collaboration_mode", {}).get("settings", {}).get("model"))
+                        if m:
+                            last_model = m
+                        continue
+
+                    # Token count events
+                    if rtype == "event_msg":
+                        payload = record.get("payload", {})
+                        if payload.get("type") != "token_count":
+                            continue
+
+                        info = record.get("info", {})
+                        ts_str = record.get("timestamp", "")
+                        sid = record.get("session_id") or record.get("sessionId")
+
+                        # Extract model
+                        model = (info.get("model") or info.get("model_name") or
+                                 (info.get("metadata") or {}).get("model") or
+                                 payload.get("model") or
+                                 (payload.get("metadata") or {}).get("model") or
+                                 last_model or "gpt-5")
+
+                        # Resolve alias
+                        model = CODEX_MODEL_ALIASES.get(model, model)
+
+                        # Token extraction: prefer last_token_usage, fallback subtract
+                        last_usage = info.get("last_token_usage") or {}
+                        total_usage = info.get("total_token_usage") or {}
+
+                        if last_usage:
+                            inp = last_usage.get("input_tokens", 0) or 0
+                            out = last_usage.get("output_tokens", 0) or 0
+                            cached_in = last_usage.get("cached_input_tokens", 0) or 0
+                        elif total_usage and sid:
+                            prev = prev_totals.get(sid, {})
+                            inp = (total_usage.get("input_tokens", 0) or 0) - (prev.get("input_tokens", 0) or 0)
+                            out = (total_usage.get("output_tokens", 0) or 0) - (prev.get("output_tokens", 0) or 0)
+                            cached_in = (total_usage.get("cached_input_tokens", 0) or 0) - (prev.get("cached_input_tokens", 0) or 0)
+                            inp = max(0, inp)
+                            out = max(0, out)
+                            cached_in = max(0, cached_in)
+                            prev_totals[sid] = dict(total_usage)
+                        else:
+                            continue
+
+                        # Clamp cached
+                        cached_in = min(cached_in, inp)
+
+                        if inp + out == 0:
+                            continue
+
+                        # Parse timestamp
+                        try:
+                            ts_dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                            ts_unix = int(ts_dt.timestamp())
+                        except Exception:
+                            ts_unix = 0
+                            ts_dt = None
+
+                        # Update session
+                        cwd = info.get("cwd") or record.get("cwd", "")
+                        if sid:
+                            if sid not in sessions:
+                                sessions[sid] = {
+                                    "session_id": sid,
+                                    "project_name": project_name_from_cwd(cwd),
+                                    "first_timestamp": ts_str,
+                                    "last_timestamp": ts_str,
+                                    "git_branch": "",
+                                    "model": model,
+                                    "provider": "codex",
+                                }
+                            else:
+                                s = sessions[sid]
+                                if ts_str and (not s["last_timestamp"] or ts_str > s["last_timestamp"]):
+                                    s["last_timestamp"] = ts_str
+                                if ts_str and (not s["first_timestamp"] or ts_str < s["first_timestamp"]):
+                                    s["first_timestamp"] = ts_str
+                                s["model"] = model
+
+                        turns.append({
+                            "session_id": sid or "unknown",
+                            "timestamp": ts_str,
+                            "model": model,
+                            "input_tokens": inp - cached_in,
+                            "output_tokens": out,
+                            "cache_read_tokens": cached_in,
+                            "cache_creation_tokens": 0,
+                            "tool_name": None,
+                            "cwd": cwd,
+                            "provider": "codex",
+                        })
+
+                        # Track latest rate_limits block
+                        rl = info.get("rate_limits") or payload.get("rate_limits")
+                        if rl and ts_unix:
+                            if latest_rate_limits is None or ts_unix > latest_rate_limits[0]:
+                                latest_rate_limits = (ts_unix, rl, filepath)
+
+        except Exception as e:
+            print(f"  Warning: error reading {filepath}: {e}")
+
+        # Upsert sessions (with provider column)
+        for s in sessions.values():
+            existing = conn.execute(
+                "SELECT 1 FROM sessions WHERE session_id = ?", (s["session_id"],)
+            ).fetchone()
+            if existing is None:
+                conn.execute("""
+                    INSERT INTO sessions
+                        (session_id, project_name, first_timestamp, last_timestamp,
+                         git_branch, total_input_tokens, total_output_tokens,
+                         total_cache_read, total_cache_creation, model, turn_count, provider)
+                    VALUES (?, ?, ?, ?, ?, 0, 0, 0, 0, ?, 0, ?)
+                """, (s["session_id"], s["project_name"], s["first_timestamp"],
+                      s["last_timestamp"], s["model"], s.get("provider", "codex")))
+
+        # Insert turns (with provider column)
+        for t in turns:
+            conn.execute("""
+                INSERT INTO turns
+                    (session_id, timestamp, model, input_tokens, output_tokens,
+                     cache_read_tokens, cache_creation_tokens, tool_name, cwd, provider)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """, (t["session_id"], t["timestamp"], t["model"],
+                  t["input_tokens"], t["output_tokens"],
+                  t["cache_read_tokens"], t["cache_creation_tokens"],
+                  t["tool_name"], t["cwd"], t.get("provider", "codex")))
+
+        # Record file
+        with open(filepath, encoding="utf-8", errors="replace") as f:
+            line_count = sum(1 for _ in f)
+        conn.execute("""
+            INSERT OR REPLACE INTO processed_files (path, mtime, lines, provider)
+            VALUES (?, ?, ?, ?)
+        """, (filepath, mtime, line_count, "codex"))
+        conn.commit()
+
+        if is_new:
+            new_files += 1
+        else:
+            updated_files += 1
+
+        total_turns += len(turns)
+        total_sessions.update(sessions.keys())
+
+    # Upsert latest rate_limits to codex_rate_limits table
+    if latest_rate_limits:
+        ts_unix, rl, src_file = latest_rate_limits
+        primary = rl.get("primary", {})
+        secondary = rl.get("secondary", {})
+        credits = rl.get("credits", {})
+
+        # primary_resets_at: parse ISO string
+        def _parse_resets(val):
+            if not val:
+                return None
+            try:
+                return int(datetime.fromisoformat(str(val).replace("Z", "+00:00")).timestamp())
+            except Exception:
+                return None
+
+        conn.execute("""
+            INSERT OR REPLACE INTO codex_rate_limits
+                (id, scraped_at, primary_pct, primary_window, primary_resets_at,
+                 secondary_pct, secondary_window, secondary_resets_at,
+                 plan_type, credits_has, credits_balance, source_file, source_ts)
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """, (
+            int(datetime.now().timestamp()),
+            primary.get("used_percent"),
+            primary.get("window"),
+            _parse_resets(primary.get("resets_at")),
+            secondary.get("used_percent"),
+            secondary.get("window"),
+            _parse_resets(secondary.get("resets_at")),
+            rl.get("plan_type"),
+            1 if credits.get("has_credits") else 0,
+            credits.get("balance", 0.0),
+            src_file,
+            ts_unix,
+        ))
+        conn.commit()
+
+    if new_files or updated_files:
+        conn.execute("""
+            UPDATE sessions SET
+                total_input_tokens = COALESCE((SELECT SUM(input_tokens) FROM turns WHERE turns.session_id = sessions.session_id), 0),
+                total_output_tokens = COALESCE((SELECT SUM(output_tokens) FROM turns WHERE turns.session_id = sessions.session_id), 0),
+                total_cache_read = COALESCE((SELECT SUM(cache_read_tokens) FROM turns WHERE turns.session_id = sessions.session_id), 0),
+                total_cache_creation = COALESCE((SELECT SUM(cache_creation_tokens) FROM turns WHERE turns.session_id = sessions.session_id), 0),
+                turn_count = COALESCE((SELECT COUNT(*) FROM turns WHERE turns.session_id = sessions.session_id), 0)
+            WHERE provider='codex'
+        """)
+        conn.commit()
+
+    if verbose:
+        print(f"\nCodex scan complete:")
+        print(f"  New files:     {new_files}")
+        print(f"  Updated files: {updated_files}")
+        print(f"  Skipped files: {skipped_files}")
+        print(f"  Turns added:   {total_turns}")
+        print(f"  Sessions seen: {len(total_sessions)}")
+
+    conn.close()
+    return {"new": new_files, "updated": updated_files, "skipped": skipped_files,
+            "turns": total_turns, "sessions": len(total_sessions)}
 
 
 def scan(projects_dir=None, projects_dirs=None, db_path=DB_PATH, verbose=True):

--- a/scanner.py
+++ b/scanner.py
@@ -73,6 +73,7 @@ def init_db(conn):
         CREATE INDEX IF NOT EXISTS idx_turns_session ON turns(session_id);
         CREATE INDEX IF NOT EXISTS idx_turns_timestamp ON turns(timestamp);
         CREATE INDEX IF NOT EXISTS idx_sessions_first ON sessions(first_timestamp);
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_turns_dedup ON turns(session_id, timestamp, provider);
     """)
     # PR 1 migrations — idempotent ALTER TABLE + new table
     try:
@@ -520,10 +521,10 @@ def scan_codex(db_path=DB_PATH, verbose=True):
                 """, (s["session_id"], s["project_name"], s["first_timestamp"],
                       s["last_timestamp"], s["model"], s.get("provider", "codex")))
 
-        # Insert turns (with provider column)
+        # Insert turns — OR IGNORE prevents dupe rows on re-scan (dedup via unique index)
         for t in turns:
             conn.execute("""
-                INSERT INTO turns
+                INSERT OR IGNORE INTO turns
                     (session_id, timestamp, model, input_tokens, output_tokens,
                      cache_read_tokens, cache_creation_tokens, tool_name, cwd, provider)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/scanner.py
+++ b/scanner.py
@@ -21,8 +21,7 @@ CODEX_PRICING = {
     "gpt-5.3-codex": {"in": 1.25, "cached_in": 0.125, "out": 10.0},
 }
 CODEX_MODEL_ALIASES = {
-    "gpt-5-codex":   "gpt-5",
-    "gpt-5.3-codex": "gpt-5.2-codex",
+    "gpt-5-codex": "gpt-5",
 }
 
 DEFAULT_PROJECTS_DIRS = [PROJECTS_DIR, XCODE_PROJECTS_DIR]


### PR DESCRIPTION
## T-07104B PR 1: Claude + Codex + UI Shell

### Changes
- **Schema migrations** (idempotent): `provider` column on `sessions`, `turns`, `processed_files`; new `codex_rate_limits` table
- **Codex JSONL scanner** (`scan_codex()` in `scanner.py`): reads `~/.codex/sessions/**/*.jsonl`, extracts token usage via `last_token_usage`/`subtractRawUsage` fallback, upserts rate-limits block
- **Codex pricing table**: hardcoded `gpt-5`/`gpt-5.2-codex`/`gpt-5.3-codex` pricing
- **3-tab dashboard layout** (Claude/Codex/Combined) with `localStorage` persistence
- **Persistent rate-limit strip**: Codex 5hr+7d gauges with reset times, Gemini placeholder
- **CLI `--provider` flag**: `python3 cli.py scan --provider claude|codex`
- **Rename**: AI Usage Dashboard (title, h1, README, CLI strings)
- **Port**: 9123

### Not in this PR
Gemini strip half, `gemini_provider.py`, Gemini tables, Gemini LaunchAgent (PR 2).

PRD: `~/.cc-agents/coder/Projects/T-07104B/prd.md`