### PR TITLE
feat: add 24h hourly view to dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -53,6 +53,32 @@ def get_dashboard_data(db_path=DB_PATH):
         "turns":          r["turns"] or 0,
     } for r in daily_rows]
 
+    # ── Hourly per-model, last 48h (for 24h view) ───────────────────────────
+    hourly_rows = conn.execute("""
+        SELECT
+            substr(timestamp, 1, 13)   as hour,
+            COALESCE(model, 'unknown') as model,
+            SUM(input_tokens)          as input,
+            SUM(output_tokens)         as output,
+            SUM(cache_read_tokens)     as cache_read,
+            SUM(cache_creation_tokens) as cache_creation,
+            COUNT(*)                   as turns
+        FROM turns
+        WHERE timestamp >= replace(datetime('now', '-48 hours'), ' ', 'T') || 'Z'
+        GROUP BY hour, model
+        ORDER BY hour, model
+    """).fetchall()
+
+    hourly_by_model = [{
+        "hour":           r["hour"],
+        "model":          r["model"],
+        "input":          r["input"] or 0,
+        "output":         r["output"] or 0,
+        "cache_read":     r["cache_read"] or 0,
+        "cache_creation": r["cache_creation"] or 0,
+        "turns":          r["turns"] or 0,
+    } for r in hourly_rows]
+
     # ── All sessions (client filters by range and model) ──────────────────────
     session_rows = conn.execute("""
         SELECT
@@ -88,10 +114,11 @@ def get_dashboard_data(db_path=DB_PATH):
     conn.close()
 
     return {
-        "all_models":     all_models,
-        "daily_by_model": daily_by_model,
-        "sessions_all":   sessions_all,
-        "generated_at":   datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "all_models":      all_models,
+        "daily_by_model":  daily_by_model,
+        "hourly_by_model": hourly_by_model,
+        "sessions_all":    sessions_all,
+        "generated_at":    datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
     }
 
 
@@ -198,6 +225,7 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
   <div class="filter-sep"></div>
   <div class="filter-label">Range</div>
   <div class="range-group">
+    <button class="range-btn" data-range="24h" onclick="setRange('24h')">24h</button>
     <button class="range-btn" data-range="7d"  onclick="setRange('7d')">7d</button>
     <button class="range-btn" data-range="30d" onclick="setRange('30d')">30d</button>
     <button class="range-btn" data-range="90d" onclick="setRange('90d')">90d</button>
@@ -365,11 +393,16 @@ const TOKEN_COLORS = {
 const MODEL_COLORS = ['#d97757','#4f8ef7','#4ade80','#a78bfa','#fbbf24','#f472b6','#34d399','#60a5fa'];
 
 // ── Time range ─────────────────────────────────────────────────────────────
-const RANGE_LABELS = { '7d': 'Last 7 Days', '30d': 'Last 30 Days', '90d': 'Last 90 Days', 'all': 'All Time' };
-const RANGE_TICKS  = { '7d': 7, '30d': 15, '90d': 13, 'all': 12 };
+const RANGE_LABELS = { '24h': 'Last 24 Hours', '7d': 'Last 7 Days', '30d': 'Last 30 Days', '90d': 'Last 90 Days', 'all': 'All Time' };
+const RANGE_TICKS  = { '24h': 24, '7d': 7, '30d': 15, '90d': 13, 'all': 12 };
 
 function getRangeCutoff(range) {
   if (range === 'all') return null;
+  if (range === '24h') {
+    const d = new Date();
+    d.setHours(d.getHours() - 24);
+    return d.toISOString().slice(0, 13);  // "YYYY-MM-DDTHH"
+  }
   const days = range === '7d' ? 7 : range === '30d' ? 30 : 90;
   const d = new Date();
   d.setDate(d.getDate() - days);
@@ -378,7 +411,7 @@ function getRangeCutoff(range) {
 
 function readURLRange() {
   const p = new URLSearchParams(window.location.search).get('range');
-  return ['7d', '30d', '90d', 'all'].includes(p) ? p : '30d';
+  return ['24h', '7d', '30d', '90d', 'all'].includes(p) ? p : '30d';
 }
 
 function setRange(range) {
@@ -501,28 +534,38 @@ function sortSessions(sessions) {
 function applyFilter() {
   if (!rawData) return;
 
+  const isHourly = selectedRange === '24h';
   const cutoff = getRangeCutoff(selectedRange);
 
-  // Filter daily rows by model + date range
-  const filteredDaily = rawData.daily_by_model.filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
-  );
+  // Filter source rows by model + range
+  let filteredRows;
+  if (isHourly) {
+    filteredRows = (rawData.hourly_by_model || []).filter(r =>
+      selectedModels.has(r.model) && r.hour >= cutoff
+    );
+  } else {
+    filteredRows = rawData.daily_by_model.filter(r =>
+      selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    );
+  }
 
-  // Daily chart: aggregate by day
-  const dailyMap = {};
-  for (const r of filteredDaily) {
-    if (!dailyMap[r.day]) dailyMap[r.day] = { day: r.day, input: 0, output: 0, cache_read: 0, cache_creation: 0 };
-    const d = dailyMap[r.day];
+  // Chart data: aggregate by time bucket
+  const bucketKey = isHourly ? 'hour' : 'day';
+  const chartMap = {};
+  for (const r of filteredRows) {
+    const key = r[bucketKey];
+    if (!chartMap[key]) chartMap[key] = { label: key, input: 0, output: 0, cache_read: 0, cache_creation: 0 };
+    const d = chartMap[key];
     d.input          += r.input;
     d.output         += r.output;
     d.cache_read     += r.cache_read;
     d.cache_creation += r.cache_creation;
   }
-  const daily = Object.values(dailyMap).sort((a, b) => a.day.localeCompare(b.day));
+  const chartBuckets = Object.values(chartMap).sort((a, b) => a.label.localeCompare(b.label));
 
-  // By model: aggregate tokens + turns from daily data
+  // By model: aggregate tokens + turns
   const modelMap = {};
-  for (const r of filteredDaily) {
+  for (const r of filteredRows) {
     if (!modelMap[r.model]) modelMap[r.model] = { model: r.model, input: 0, output: 0, cache_read: 0, cache_creation: 0, turns: 0, sessions: 0 };
     const m = modelMap[r.model];
     m.input          += r.input;
@@ -532,10 +575,18 @@ function applyFilter() {
     m.turns          += r.turns;
   }
 
-  // Filter sessions by model + date range
-  const filteredSessions = rawData.sessions_all.filter(s =>
-    selectedModels.has(s.model) && (!cutoff || s.last_date >= cutoff)
-  );
+  // Filter sessions by model + range
+  let filteredSessions;
+  if (isHourly) {
+    const sessionCutoff = cutoff.replace('T', ' ');  // "YYYY-MM-DD HH"
+    filteredSessions = rawData.sessions_all.filter(s =>
+      selectedModels.has(s.model) && s.last >= sessionCutoff
+    );
+  } else {
+    filteredSessions = rawData.sessions_all.filter(s =>
+      selectedModels.has(s.model) && (!cutoff || s.last_date >= cutoff)
+    );
+  }
 
   // Add session counts into modelMap
   for (const s of filteredSessions) {
@@ -570,11 +621,12 @@ function applyFilter() {
     cost:           byModel.reduce((s, m) => s + calcCost(m.model, m.input, m.output, m.cache_read, m.cache_creation), 0),
   };
 
-  // Update daily chart title
-  document.getElementById('daily-chart-title').textContent = 'Daily Token Usage \u2014 ' + RANGE_LABELS[selectedRange];
+  // Update chart title
+  const chartPrefix = isHourly ? 'Hourly' : 'Daily';
+  document.getElementById('daily-chart-title').textContent = chartPrefix + ' Token Usage \u2014 ' + RANGE_LABELS[selectedRange];
 
   renderStats(totals);
-  renderDailyChart(daily);
+  renderDailyChart(chartBuckets, isHourly);
   renderModelChart(byModel);
   renderProjectChart(byProject);
   lastFilteredSessions = sortSessions(filteredSessions);
@@ -605,18 +657,26 @@ function renderStats(t) {
   `).join('');
 }
 
-function renderDailyChart(daily) {
+function fmtHourLabel(label) {
+  // label = "YYYY-MM-DDTHH" → "MM/DD HH:00"
+  const date = label.slice(5, 10);  // "MM-DD"
+  const hour = label.slice(11, 13); // "HH"
+  return date + ' ' + hour + ':00';
+}
+
+function renderDailyChart(data, isHourly) {
   const ctx = document.getElementById('chart-daily').getContext('2d');
   if (charts.daily) charts.daily.destroy();
+  const labels = data.map(d => isHourly ? fmtHourLabel(d.label) : d.label);
   charts.daily = new Chart(ctx, {
     type: 'bar',
     data: {
-      labels: daily.map(d => d.day),
+      labels: labels,
       datasets: [
-        { label: 'Input',          data: daily.map(d => d.input),          backgroundColor: TOKEN_COLORS.input,          stack: 'tokens' },
-        { label: 'Output',         data: daily.map(d => d.output),         backgroundColor: TOKEN_COLORS.output,         stack: 'tokens' },
-        { label: 'Cache Read',     data: daily.map(d => d.cache_read),     backgroundColor: TOKEN_COLORS.cache_read,     stack: 'tokens' },
-        { label: 'Cache Creation', data: daily.map(d => d.cache_creation), backgroundColor: TOKEN_COLORS.cache_creation, stack: 'tokens' },
+        { label: 'Input',          data: data.map(d => d.input),          backgroundColor: TOKEN_COLORS.input,          stack: 'tokens' },
+        { label: 'Output',         data: data.map(d => d.output),         backgroundColor: TOKEN_COLORS.output,         stack: 'tokens' },
+        { label: 'Cache Read',     data: data.map(d => d.cache_read),     backgroundColor: TOKEN_COLORS.cache_read,     stack: 'tokens' },
+        { label: 'Cache Creation', data: data.map(d => d.cache_creation), backgroundColor: TOKEN_COLORS.cache_creation, stack: 'tokens' },
       ]
     },
     options: {

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -7,6 +7,7 @@ import tempfile
 import threading
 import unittest
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 
 from scanner import get_db, init_db, upsert_sessions, insert_turns
@@ -53,6 +54,7 @@ class TestGetDashboardData(unittest.TestCase):
         data = get_dashboard_data(db_path=self.db_path)
         self.assertIn("all_models", data)
         self.assertIn("daily_by_model", data)
+        self.assertIn("hourly_by_model", data)
         self.assertIn("sessions_all", data)
         self.assertIn("generated_at", data)
 
@@ -90,6 +92,96 @@ class TestGetDashboardData(unittest.TestCase):
         session = data["sessions_all"][0]
         # 1 hour = 60 minutes
         self.assertEqual(session["duration_min"], 60.0)
+
+    def test_hourly_excludes_old_data(self):
+        """Turns from 2026-04-08 fall outside the 48h window."""
+        data = get_dashboard_data(db_path=self.db_path)
+        self.assertEqual(len(data["hourly_by_model"]), 0)
+
+
+class TestHourlyData(unittest.TestCase):
+    """Tests for the 24h hourly view feature."""
+
+    def setUp(self):
+        self.tmpfile = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmpfile.close()
+        self.db_path = Path(self.tmpfile.name)
+        conn = get_db(self.db_path)
+        init_db(conn)
+        # Insert a session
+        sessions = [{
+            "session_id": "sess-hourly1", "project_name": "user/hourlytest",
+            "first_timestamp": "2026-04-08T09:00:00Z",
+            "last_timestamp": "2026-04-08T10:00:00Z",
+            "git_branch": "main", "model": "claude-sonnet-4-6",
+            "total_input_tokens": 0, "total_output_tokens": 0,
+            "total_cache_read": 0, "total_cache_creation": 0,
+            "turn_count": 0,
+        }]
+        upsert_sessions(conn, sessions)
+        # Insert turns with recent timestamps (within 48h window)
+        now = datetime.now(timezone.utc)
+        self.recent_hour = now.strftime("%Y-%m-%dT%H")
+        turns = [
+            {
+                "session_id": "sess-hourly1",
+                "timestamp": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "model": "claude-sonnet-4-6", "input_tokens": 100,
+                "output_tokens": 50, "cache_read_tokens": 10,
+                "cache_creation_tokens": 5, "tool_name": None, "cwd": "/tmp",
+            },
+            {
+                "session_id": "sess-hourly1",
+                "timestamp": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "model": "claude-opus-4-6", "input_tokens": 200,
+                "output_tokens": 100, "cache_read_tokens": 20,
+                "cache_creation_tokens": 10, "tool_name": None, "cwd": "/tmp",
+            },
+        ]
+        insert_turns(conn, turns)
+        conn.commit()
+        conn.close()
+
+    def tearDown(self):
+        os.unlink(self.db_path)
+
+    def test_hourly_populated(self):
+        data = get_dashboard_data(db_path=self.db_path)
+        self.assertGreater(len(data["hourly_by_model"]), 0)
+
+    def test_hourly_row_structure(self):
+        data = get_dashboard_data(db_path=self.db_path)
+        row = data["hourly_by_model"][0]
+        for key in ("hour", "model", "input", "output", "cache_read",
+                     "cache_creation", "turns"):
+            self.assertIn(key, row)
+
+    def test_hourly_hour_format(self):
+        """Hour field should be 'YYYY-MM-DDTHH' (13 chars)."""
+        data = get_dashboard_data(db_path=self.db_path)
+        row = data["hourly_by_model"][0]
+        self.assertEqual(len(row["hour"]), 13)
+        self.assertIn("T", row["hour"])
+
+    def test_hourly_per_model_separation(self):
+        """Two models in the same hour should produce separate rows."""
+        data = get_dashboard_data(db_path=self.db_path)
+        hourly = data["hourly_by_model"]
+        models = {r["model"] for r in hourly if r["hour"] == self.recent_hour}
+        self.assertIn("claude-sonnet-4-6", models)
+        self.assertIn("claude-opus-4-6", models)
+
+    def test_hourly_token_values(self):
+        data = get_dashboard_data(db_path=self.db_path)
+        hourly = data["hourly_by_model"]
+        sonnet = [r for r in hourly if r["model"] == "claude-sonnet-4-6"
+                  and r["hour"] == self.recent_hour]
+        self.assertEqual(len(sonnet), 1)
+        self.assertEqual(sonnet[0]["input"], 100)
+        self.assertEqual(sonnet[0]["output"], 50)
+        self.assertEqual(sonnet[0]["cache_read"], 10)
+        self.assertEqual(sonnet[0]["cache_creation"], 5)
+        self.assertEqual(sonnet[0]["turns"], 1)
 
 
 class TestDashboardHTTP(unittest.TestCase):
@@ -163,6 +255,15 @@ class TestHTMLTemplate(unittest.TestCase):
     def test_unknown_models_return_null(self):
         """Verify getPricing returns null for non-Anthropic models."""
         self.assertIn("return null;", HTML_TEMPLATE)
+
+    def test_template_has_24h_range_button(self):
+        self.assertIn('data-range="24h"', HTML_TEMPLATE)
+
+    def test_template_has_hourly_label_formatter(self):
+        self.assertIn("function fmtHourLabel(", HTML_TEMPLATE)
+
+    def test_template_has_hourly_range_label(self):
+        self.assertIn("'24h': 'Last 24 Hours'", HTML_TEMPLATE)
 
 
 class TestPricingParity(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Add a **24h** range button to the dashboard that shows token usage broken down by hour
- Backend serves hourly aggregated data (last 48h) alongside existing daily data
- Chart, stats, and session table all respond to the 24h range with hour-precision filtering
- X-axis labels formatted as `MM-DD HH:00` for readability

## Test plan
- [x] 9 new tests added (93 total, all passing)
- [x] Verified API returns `hourly_by_model` data with correct structure
- [x] Tested 24h button renders hourly bar chart
- [x] Confirmed existing daily ranges (7d, 30d, 90d, All) unchanged
- [x] URL persistence works with `?range=24h`

🤖 Generated with [Claude Code](https://claude.com/claude-code)