### PR TITLE
fix: two macOS dashboard startup bugs

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -274,9 +274,14 @@ def cmd_dashboard(projects_dir=None):
     host = os.environ.get("HOST", "localhost")
     port = int(os.environ.get("PORT", "8080"))
 
+    # 0.0.0.0 / :: are wildcard bind addresses; browsers can't connect to them.
+    # Map to the loopback address so the opened URL is always reachable.
+    _WILDCARD_TO_LOOPBACK = {"0.0.0.0": "127.0.0.1", "::": "[::1]"}
+    browser_host = _WILDCARD_TO_LOOPBACK.get(host, host)
+
     def open_browser():
         time.sleep(1.0)
-        webbrowser.open(f"http://{host}:{port}")
+        webbrowser.open(f"http://{browser_host}:{port}")
 
     t = threading.Thread(target=open_browser, daemon=True)
     t.start()

--- a/dashboard.py
+++ b/dashboard.py
@@ -932,10 +932,29 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self.end_headers()
 
 
+class _StrictHTTPServer(HTTPServer):
+    # HTTPServer sets allow_reuse_address = True, which lets bind() succeed
+    # silently when another process already owns the port (SO_REUSEADDR). Disable
+    # it so we get a clear EADDRINUSE error instead of a silent no-op server.
+    allow_reuse_address = False
+
+
 def serve(host=None, port=None):
+    import errno
+    import sys
+
     host = host or os.environ.get("HOST", "localhost")
     port = port or int(os.environ.get("PORT", "8080"))
-    server = HTTPServer((host, port), DashboardHandler)
+
+    try:
+        server = _StrictHTTPServer((host, port), DashboardHandler)
+    except OSError as exc:
+        if exc.errno == errno.EADDRINUSE:
+            print(f"Error: port {port} is already in use.")
+            print(f"  Stop the other server, or set a different port: PORT=9000 python cli.py dashboard")
+            sys.exit(1)
+        raise
+
     print(f"Dashboard running at http://{host}:{port}")
     print("Press Ctrl+C to stop.")
     try:


### PR DESCRIPTION
## Summary

- **Wildcard host in browser URL**: When `HOST=0.0.0.0`, the HTTP server binds correctly to all interfaces, but the browser URL `http://0.0.0.0:port` is not routable on macOS — the browser returns `ERR_SSL_PROTOCOL_ERROR`. The fix maps wildcard bind addresses (`0.0.0.0` → `127.0.0.1`, `::` → `[::1]`) for the browser URL only; the server continues binding to the original host.

- **Port conflict silently ignored**: Python's `HTTPServer` sets `allow_reuse_address = True` (`SO_REUSEADDR`), which lets `bind()` succeed when another process already owns the port. The server would start, print its running message, then serve nothing (the existing server captured all connections). The fix subclasses `HTTPServer` with `allow_reuse_address = False` so the OS raises `EADDRINUSE` on conflict, then catches it and reports a clear actionable error.

## Test results

```
PASS  Test 1: HOST=0.0.0.0 -> browser URL uses 127.0.0.1
PASS  Test 2: HOST=localhost (default) -> browser URL uses localhost
PASS  Test 3: HOST=127.0.0.1 (explicit) -> browser URL uses 127.0.0.1
PASS  Test 4: port conflict -> exit 1 with message: Error: port 19999 is already in use.
                Stop the other server, or set a different port: PORT=9000 python cli.py dashboard
```

## Test plan

- [ ] `HOST=0.0.0.0 PORT=9000 python3 cli.py dashboard` — browser opens at `http://127.0.0.1:9000` and loads correctly on macOS
- [ ] `python3 cli.py dashboard` (default) — browser opens at `http://localhost:8080`
- [ ] `HOST=127.0.0.1 PORT=9000 python3 cli.py dashboard` — browser opens at `http://127.0.0.1:9000`
- [ ] Start another server on port 8080, then run `python3 cli.py dashboard` — prints clear error and exits instead of silently failing