### PR TITLE
fix: add Opus 4.7 to pricing tables (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Costs are calculated using **Anthropic API pricing as of April 2026** ([claude.c
 
 | Model | Input | Output | Cache Write | Cache Read |
 |-------|-------|--------|------------|-----------|
+| claude-opus-4-7 | $5.00/MTok | $25.00/MTok | $6.25/MTok | $0.50/MTok |
 | claude-opus-4-6 | $5.00/MTok | $25.00/MTok | $6.25/MTok | $0.50/MTok |
 | claude-sonnet-4-6 | $3.00/MTok | $15.00/MTok | $3.75/MTok | $0.30/MTok |
 | claude-haiku-4-5 | $1.00/MTok | $5.00/MTok | $1.25/MTok | $0.10/MTok |

--- a/cli.py
+++ b/cli.py
@@ -17,12 +17,15 @@ from datetime import datetime, date
 DB_PATH = Path.home() / ".claude" / "usage.db"
 
 PRICING = {
+    "claude-opus-4-7":   {"input":  5.00, "output": 25.00},
     "claude-opus-4-6":   {"input":  5.00, "output": 25.00},
     "claude-opus-4-5":   {"input":  5.00, "output": 25.00},
+    "claude-sonnet-4-7": {"input":  3.00, "output": 15.00},
     "claude-sonnet-4-6": {"input":  3.00, "output": 15.00},
     "claude-sonnet-4-5": {"input":  3.00, "output": 15.00},
-    "claude-haiku-4-5":  {"input":  1.00, "output":  5.00},
+    "claude-haiku-4-7":  {"input":  1.00, "output":  5.00},
     "claude-haiku-4-6":  {"input":  1.00, "output":  5.00},
+    "claude-haiku-4-5":  {"input":  1.00, "output":  5.00},
 }
 
 def get_pricing(model):
@@ -36,7 +39,7 @@ def get_pricing(model):
     # Substring fallback: match model family by keyword
     m = model.lower()
     if "opus" in m:
-        return PRICING["claude-opus-4-6"]
+        return PRICING["claude-opus-4-7"]
     if "sonnet" in m:
         return PRICING["claude-sonnet-4-6"]
     if "haiku" in m:

--- a/dashboard.py
+++ b/dashboard.py
@@ -261,12 +261,15 @@ let charts = {};
 
 // ── Pricing (Anthropic API, April 2026) ────────────────────────────────────
 const PRICING = {
+  'claude-opus-4-7':   { input:  5.00, output: 25.00, cache_write:  6.25, cache_read: 0.50 },
   'claude-opus-4-6':   { input:  5.00, output: 25.00, cache_write:  6.25, cache_read: 0.50 },
   'claude-opus-4-5':   { input:  5.00, output: 25.00, cache_write:  6.25, cache_read: 0.50 },
+  'claude-sonnet-4-7': { input:  3.00, output: 15.00, cache_write:  3.75, cache_read: 0.30 },
   'claude-sonnet-4-6': { input:  3.00, output: 15.00, cache_write:  3.75, cache_read: 0.30 },
   'claude-sonnet-4-5': { input:  3.00, output: 15.00, cache_write:  3.75, cache_read: 0.30 },
-  'claude-haiku-4-5':  { input:  1.00, output:  5.00, cache_write:  1.25, cache_read: 0.10 },
+  'claude-haiku-4-7':  { input:  1.00, output:  5.00, cache_write:  1.25, cache_read: 0.10 },
   'claude-haiku-4-6':  { input:  1.00, output:  5.00, cache_write:  1.25, cache_read: 0.10 },
+  'claude-haiku-4-5':  { input:  1.00, output:  5.00, cache_write:  1.25, cache_read: 0.10 },
 };
 
 function isBillable(model) {
@@ -282,7 +285,7 @@ function getPricing(model) {
     if (model.startsWith(key)) return PRICING[key];
   }
   const m = model.toLowerCase();
-  if (m.includes('opus'))   return PRICING['claude-opus-4-6'];
+  if (m.includes('opus'))   return PRICING['claude-opus-4-7'];
   if (m.includes('sonnet')) return PRICING['claude-sonnet-4-6'];
   if (m.includes('haiku'))  return PRICING['claude-haiku-4-5'];
   return null;

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,12 +11,24 @@ class TestGetPricing(unittest.TestCase):
         self.assertEqual(p["output"], 25.00)
 
     def test_all_known_models_have_pricing(self):
-        for model in ("claude-opus-4-6", "claude-opus-4-5",
-                       "claude-sonnet-4-6", "claude-sonnet-4-5",
-                       "claude-haiku-4-5", "claude-haiku-4-6"):
+        for model in ("claude-opus-4-7", "claude-opus-4-6", "claude-opus-4-5",
+                       "claude-sonnet-4-7", "claude-sonnet-4-6", "claude-sonnet-4-5",
+                       "claude-haiku-4-7", "claude-haiku-4-6", "claude-haiku-4-5"):
             p = get_pricing(model)
             self.assertGreater(p["input"], 0, f"Missing input price for {model}")
             self.assertGreater(p["output"], 0, f"Missing output price for {model}")
+
+    def test_opus_4_7_has_explicit_entry(self):
+        """Regression guard for issue #61 — Opus 4.7 must be present."""
+        p = get_pricing("claude-opus-4-7")
+        self.assertEqual(p["input"], 5.00)
+        self.assertEqual(p["output"], 25.00)
+
+    def test_opus_4_7_with_date_suffix(self):
+        """Model strings from JSONL often have date suffixes."""
+        p = get_pricing("claude-opus-4-7-20260215")
+        self.assertEqual(p["input"], 5.00)
+        self.assertEqual(p["output"], 25.00)
 
     def test_prefix_match(self):
         # A model name with a suffix should still match the base
@@ -134,19 +146,19 @@ class TestPricingConsistency(unittest.TestCase):
     """Ensure CLI pricing matches known Anthropic API rates."""
 
     def test_opus_pricing(self):
-        for model in ("claude-opus-4-6", "claude-opus-4-5"):
+        for model in ("claude-opus-4-7", "claude-opus-4-6", "claude-opus-4-5"):
             p = get_pricing(model)
             self.assertEqual(p["input"], 5.00, f"{model} input price wrong")
             self.assertEqual(p["output"], 25.00, f"{model} output price wrong")
 
     def test_sonnet_pricing(self):
-        for model in ("claude-sonnet-4-6", "claude-sonnet-4-5"):
+        for model in ("claude-sonnet-4-7", "claude-sonnet-4-6", "claude-sonnet-4-5"):
             p = get_pricing(model)
             self.assertEqual(p["input"], 3.00, f"{model} input price wrong")
             self.assertEqual(p["output"], 15.00, f"{model} output price wrong")
 
     def test_haiku_pricing(self):
-        for model in ("claude-haiku-4-5", "claude-haiku-4-6"):
+        for model in ("claude-haiku-4-7", "claude-haiku-4-6", "claude-haiku-4-5"):
             p = get_pricing(model)
             self.assertEqual(p["input"], 1.00, f"{model} input price wrong")
             self.assertEqual(p["output"], 5.00, f"{model} output price wrong")


### PR DESCRIPTION
## Summary

Fixes #61 — Opus 4.7 wasn't getting explicit pricing in either the CLI or dashboard tables, so sessions using `claude-opus-4-7` (and any dated variants such as `claude-opus-4-7-20260215`) relied on the substring fallback. That fallback was still pointed at 4-6.

- Adds `claude-opus-4-7` to `PRICING` in both `cli.py` and `dashboard.py`, plus matching `sonnet-4-7` / `haiku-4-7` entries for forward compatibility (same pattern already used for 4-5 and 4-6 across all three families).
- Updates the "opus" substring fallback to point at 4-7 so dated suffix variants resolve to the newest Opus rates.
- Updates the README pricing table.
- Adds regression tests that assert the 4-7 entries exist and that `claude-opus-4-7-YYYYMMDD` matches correctly.

## Test plan
- [x] `python -m pytest` — 71 passed (2 new)
- [x] Pricing parity test (`test_all_cli_models_in_dashboard`, `test_prices_match`) still passes, confirming CLI and dashboard JS tables remain in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)