### PR TITLE
feat: display session names from /rename in dashboard (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add session name support: the dashboard now shows the human-readable name set via Claude Code's `/rename` (from `customTitle` / `agentName` JSONL records), alongside the session ID, and exports it to CSV (#56)
+
 ## 2026-04-09
 
 - Fix token counts inflated ~2x by deduplicating streaming events that share the same message ID

--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -77,15 +77,28 @@ def get_dashboard_data(db_path=DB_PATH):
     } for r in hourly_rows]
 
     # ── All sessions (client filters by range and model) ──────────────────────
-    session_rows = conn.execute("""
-        SELECT
-            session_id, project_name, first_timestamp, last_timestamp,
-            total_input_tokens, total_output_tokens,
-            total_cache_read, total_cache_creation, model, turn_count,
-            git_branch
-        FROM sessions
-        ORDER BY last_timestamp DESC
-    """).fetchall()
+    # session_name may be missing on older DB schemas; fall back gracefully.
+    try:
+        session_rows = conn.execute("""
+            SELECT
+                session_id, project_name, first_timestamp, last_timestamp,
+                total_input_tokens, total_output_tokens,
+                total_cache_read, total_cache_creation, model, turn_count,
+                git_branch, session_name
+            FROM sessions
+            ORDER BY last_timestamp DESC
+        """).fetchall()
+    except sqlite3.OperationalError:
+        # Pre-migration DB: synthesise session_name=None
+        session_rows = conn.execute("""
+            SELECT
+                session_id, project_name, first_timestamp, last_timestamp,
+                total_input_tokens, total_output_tokens,
+                total_cache_read, total_cache_creation, model, turn_count,
+                git_branch, NULL AS session_name
+            FROM sessions
+            ORDER BY last_timestamp DESC
+        """).fetchall()
 
     sessions_all = []
     for r in session_rows:
@@ -97,6 +110,7 @@ def get_dashboard_data(db_path=DB_PATH):
             duration_min = 0
         sessions_all.append({
             "session_id":    r["session_id"][:8],
+            "session_name":  r["session_name"] or "",
             "project":       r["project_name"] or "unknown",
             "branch":        r["git_branch"] or "",
             "last":          (r["last_timestamp"] or "")[:16].replace("T", " "),
@@ -199,6 +213,7 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
   tr:last-child td { border-bottom: none; }
   tr:hover td { background: rgba(255,255,255,0.02); }
   .model-tag { display: inline-block; padding: 2px 7px; border-radius: 4px; font-size: 11px; background: rgba(79,142,247,0.15); color: var(--blue); }
+  .session-name { color: var(--text); font-weight: 600; }
   .cost { color: var(--green); font-family: monospace; }
   .cost-na { color: var(--muted); font-family: monospace; font-size: 11px; }
   .num { font-family: monospace; }
@@ -960,8 +975,11 @@ function renderSessionsTable(sessions) {
     const costCell = isBillable(s.model)
       ? `<td class="cost">${fmtCost(cost)}</td>`
       : `<td class="cost-na">n/a</td>`;
+    const sessionCell = s.session_name
+      ? `<td><span class="session-name">${esc(s.session_name)}</span> <span class="muted" style="font-family:monospace">(${esc(s.session_id)}&hellip;)</span></td>`
+      : `<td class="muted" style="font-family:monospace">${esc(s.session_id)}&hellip;</td>`;
     return `<tr>
-      <td class="muted" style="font-family:monospace">${esc(s.session_id)}&hellip;</td>
+      ${sessionCell}
       <td>${esc(s.project)}</td>
       <td class="muted">${esc(s.last)}</td>
       <td class="muted">${esc(s.duration_min)}m</td>
@@ -1141,10 +1159,10 @@ function downloadCSV(reportType, header, rows) {
 }
 
 function exportSessionsCSV() {
-  const header = ['Session', 'Project', 'Last Active', 'Duration (min)', 'Model', 'Turns', 'Input', 'Output', 'Cache Read', 'Cache Creation', 'Est. Cost'];
+  const header = ['Session ID', 'Session Name', 'Project', 'Last Active', 'Duration (min)', 'Model', 'Turns', 'Input', 'Output', 'Cache Read', 'Cache Creation', 'Est. Cost'];
   const rows = lastFilteredSessions.map(s => {
     const cost = calcCost(s.model, s.input, s.output, s.cache_read, s.cache_creation);
-    return [s.session_id, s.project, s.last, s.duration_min, s.model, s.turns, s.input, s.output, s.cache_read, s.cache_creation, cost.toFixed(4)];
+    return [s.session_id, s.session_name || '', s.project, s.last, s.duration_min, s.model, s.turns, s.input, s.output, s.cache_read, s.cache_creation, cost.toFixed(4)];
   });
   downloadCSV('sessions', header, rows);
 }

--- a/scanner.py
+++ b/scanner.py
@@ -51,7 +51,8 @@ def init_db(conn):
             total_cache_read        INTEGER DEFAULT 0,
             total_cache_creation    INTEGER DEFAULT 0,
             model           TEXT,
-            turn_count      INTEGER DEFAULT 0
+            turn_count      INTEGER DEFAULT 0,
+            session_name    TEXT
         );
 
         CREATE TABLE IF NOT EXISTS turns (
@@ -83,12 +84,39 @@ def init_db(conn):
         conn.execute("SELECT message_id FROM turns LIMIT 1")
     except sqlite3.OperationalError:
         conn.execute("ALTER TABLE turns ADD COLUMN message_id TEXT")
+    # Add session_name column if upgrading from older schema
+    try:
+        conn.execute("SELECT session_name FROM sessions LIMIT 1")
+    except sqlite3.OperationalError:
+        conn.execute("ALTER TABLE sessions ADD COLUMN session_name TEXT")
     # Conditional unique index: only dedup non-null message IDs
     conn.execute("""
         CREATE UNIQUE INDEX IF NOT EXISTS idx_turns_message_id
         ON turns(message_id) WHERE message_id IS NOT NULL AND message_id != ''
     """)
     conn.commit()
+
+
+def extract_session_name(record, current_custom, current_agent):
+    """Extract customTitle / agentName from a record, preferring non-empty updates.
+
+    Claude Code logs emit `{"type":"custom-title","customTitle":"..."}` and
+    `{"type":"agent-name","agentName":"..."}` records when a session is renamed
+    via `/rename`. The last non-empty value per session wins, with customTitle
+    taking precedence over agentName at display time.
+    """
+    ct = record.get("customTitle")
+    an = record.get("agentName")
+    if ct:
+        current_custom = ct
+    if an:
+        current_agent = an
+    return current_custom, current_agent
+
+
+def resolve_session_name(custom_title, agent_name):
+    """Return the preferred display name: customTitle first, agentName second."""
+    return custom_title or agent_name or None
 
 
 def project_name_from_cwd(cwd):
@@ -125,36 +153,49 @@ def parse_jsonl_file(filepath):
                 except json.JSONDecodeError:
                     continue
 
-                rtype = record.get("type")
-                if rtype not in ("assistant", "user"):
-                    continue
-
                 session_id = record.get("sessionId")
                 if not session_id:
+                    continue
+
+                # Initialise meta on first sight of a session, regardless of record type
+                if session_id not in session_meta:
+                    session_meta[session_id] = {
+                        "session_id": session_id,
+                        "project_name": project_name_from_cwd(record.get("cwd", "")),
+                        "first_timestamp": record.get("timestamp", ""),
+                        "last_timestamp": record.get("timestamp", ""),
+                        "git_branch": record.get("gitBranch", ""),
+                        "model": None,
+                        "custom_title": None,
+                        "agent_name": None,
+                    }
+
+                # Capture session_name from any record (custom-title / agent-name types
+                # emit it as a top-level field, but the issue notes it can appear opportunistically)
+                meta = session_meta[session_id]
+                meta["custom_title"], meta["agent_name"] = extract_session_name(
+                    record, meta["custom_title"], meta["agent_name"]
+                )
+
+                rtype = record.get("type")
+                if rtype not in ("assistant", "user"):
                     continue
 
                 timestamp = record.get("timestamp", "")
                 cwd = record.get("cwd", "")
                 git_branch = record.get("gitBranch", "")
 
-                # Update session metadata from any record
-                if session_id not in session_meta:
-                    session_meta[session_id] = {
-                        "session_id": session_id,
-                        "project_name": project_name_from_cwd(cwd),
-                        "first_timestamp": timestamp,
-                        "last_timestamp": timestamp,
-                        "git_branch": git_branch,
-                        "model": None,
-                    }
-                else:
-                    meta = session_meta[session_id]
-                    if timestamp and (not meta["first_timestamp"] or timestamp < meta["first_timestamp"]):
-                        meta["first_timestamp"] = timestamp
-                    if timestamp and (not meta["last_timestamp"] or timestamp > meta["last_timestamp"]):
-                        meta["last_timestamp"] = timestamp
-                    if git_branch and not meta["git_branch"]:
-                        meta["git_branch"] = git_branch
+                # Update session metadata from assistant/user records
+                if timestamp and (not meta["first_timestamp"] or timestamp < meta["first_timestamp"]):
+                    meta["first_timestamp"] = timestamp
+                if timestamp and (not meta["last_timestamp"] or timestamp > meta["last_timestamp"]):
+                    meta["last_timestamp"] = timestamp
+                if git_branch and not meta["git_branch"]:
+                    meta["git_branch"] = git_branch
+                # Backfill project_name if the record that created meta lacked cwd
+                # (e.g. a custom-title record preceded the first user/assistant line)
+                if cwd and (not meta["project_name"] or meta["project_name"] == "unknown"):
+                    meta["project_name"] = project_name_from_cwd(cwd)
 
                 if rtype == "assistant":
                     msg = record.get("message", {})
@@ -240,7 +281,11 @@ def aggregate_sessions(session_metas, turns):
     for meta in session_metas:
         sid = meta["session_id"]
         stats = session_stats[sid]
-        result.append({**meta, **stats})
+        merged = {**meta, **stats}
+        merged["session_name"] = resolve_session_name(
+            meta.get("custom_title"), meta.get("agent_name")
+        )
+        result.append(merged)
     return result
 
 
@@ -258,14 +303,15 @@ def upsert_sessions(conn, sessions):
                 INSERT INTO sessions
                     (session_id, project_name, first_timestamp, last_timestamp,
                      git_branch, total_input_tokens, total_output_tokens,
-                     total_cache_read, total_cache_creation, model, turn_count)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     total_cache_read, total_cache_creation, model, turn_count,
+                     session_name)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 s["session_id"], s["project_name"], s["first_timestamp"],
                 s["last_timestamp"], s["git_branch"],
                 s["total_input_tokens"], s["total_output_tokens"],
                 s["total_cache_read"], s["total_cache_creation"],
-                s["model"], s["turn_count"]
+                s["model"], s["turn_count"], s.get("session_name")
             ))
         else:
             # Update: add new tokens on top of existing (since we only insert new turns)
@@ -280,6 +326,8 @@ def upsert_sessions(conn, sessions):
             else:
                 model_to_set = existing_model
 
+            # session_name: replace only when we have a new non-empty value, to avoid
+            # clobbering an existing name with a later scan that sees no rename records
             conn.execute("""
                 UPDATE sessions SET
                     last_timestamp = MAX(last_timestamp, ?),
@@ -288,13 +336,15 @@ def upsert_sessions(conn, sessions):
                     total_cache_read = total_cache_read + ?,
                     total_cache_creation = total_cache_creation + ?,
                     turn_count = turn_count + ?,
-                    model = ?
+                    model = ?,
+                    session_name = COALESCE(NULLIF(?, ''), session_name)
                 WHERE session_id = ?
             """, (
                 s["last_timestamp"],
                 s["total_input_tokens"], s["total_output_tokens"],
                 s["total_cache_read"], s["total_cache_creation"],
                 s["turn_count"], model_to_set,
+                s.get("session_name"),
                 s["session_id"]
             ))
 
@@ -394,31 +444,40 @@ def scan(projects_dir=None, projects_dirs=None, db_path=DB_PATH, verbose=True):
                         except json.JSONDecodeError:
                             continue
 
-                        rtype = record.get("type")
-                        if rtype not in ("assistant", "user"):
-                            continue
-
                         session_id = record.get("sessionId")
                         if not session_id:
+                            continue
+
+                        # Initialise meta on first sight, regardless of record type
+                        if session_id not in new_session_metas:
+                            new_session_metas[session_id] = {
+                                "session_id": session_id,
+                                "project_name": project_name_from_cwd(record.get("cwd", "")),
+                                "first_timestamp": record.get("timestamp", ""),
+                                "last_timestamp": record.get("timestamp", ""),
+                                "git_branch": record.get("gitBranch", ""),
+                                "model": None,
+                                "custom_title": None,
+                                "agent_name": None,
+                            }
+
+                        # Capture session_name updates from any record
+                        meta = new_session_metas[session_id]
+                        meta["custom_title"], meta["agent_name"] = extract_session_name(
+                            record, meta["custom_title"], meta["agent_name"]
+                        )
+
+                        rtype = record.get("type")
+                        if rtype not in ("assistant", "user"):
                             continue
 
                         timestamp = record.get("timestamp", "")
                         cwd = record.get("cwd", "")
 
-                        # Track session metadata from new lines
-                        if session_id not in new_session_metas:
-                            new_session_metas[session_id] = {
-                                "session_id": session_id,
-                                "project_name": project_name_from_cwd(cwd),
-                                "first_timestamp": timestamp,
-                                "last_timestamp": timestamp,
-                                "git_branch": record.get("gitBranch", ""),
-                                "model": None,
-                            }
-                        else:
-                            meta = new_session_metas[session_id]
-                            if timestamp and (not meta["last_timestamp"] or timestamp > meta["last_timestamp"]):
-                                meta["last_timestamp"] = timestamp
+                        if timestamp and (not meta["last_timestamp"] or timestamp > meta["last_timestamp"]):
+                            meta["last_timestamp"] = timestamp
+                        if cwd and (not meta["project_name"] or meta["project_name"] == "unknown"):
+                            meta["project_name"] = project_name_from_cwd(cwd)
 
                         if rtype == "assistant":
                             msg = record.get("message", {})

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -124,6 +124,51 @@ class TestGetDashboardData(unittest.TestCase):
         self.assertTrue(all(r["model"] == "claude-sonnet-4-6" for r in rows))
         self.assertTrue(all(r["day"] == "2026-04-08" for r in rows))
 
+    def test_session_name_field_present(self):
+        """sessions_all entries must always include a session_name key (empty by default)."""
+        data = get_dashboard_data(db_path=self.db_path)
+        session = data["sessions_all"][0]
+        self.assertIn("session_name", session)
+        self.assertEqual(session["session_name"], "")
+
+
+class TestSessionNameInDashboard(unittest.TestCase):
+    """Verify session_name from the sessions table surfaces in dashboard output."""
+
+    def setUp(self):
+        self.tmpfile = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmpfile.close()
+        self.db_path = Path(self.tmpfile.name)
+        conn = get_db(self.db_path)
+        init_db(conn)
+        conn.execute("""
+            INSERT INTO sessions
+                (session_id, project_name, first_timestamp, last_timestamp,
+                 git_branch, total_input_tokens, total_output_tokens,
+                 total_cache_read, total_cache_creation, model, turn_count,
+                 session_name)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """, (
+            "named-session-xyz", "user/proj",
+            "2026-04-08T09:00:00Z", "2026-04-08T10:00:00Z",
+            "main", 100, 50, 0, 0, "claude-sonnet-4-6", 1, "clip-research",
+        ))
+        conn.commit()
+        conn.close()
+
+    def tearDown(self):
+        os.unlink(self.db_path)
+
+    def test_session_name_returned_in_api(self):
+        data = get_dashboard_data(db_path=self.db_path)
+        self.assertEqual(data["sessions_all"][0]["session_name"], "clip-research")
+
+    def test_session_id_still_truncated_alongside_name(self):
+        data = get_dashboard_data(db_path=self.db_path)
+        session = data["sessions_all"][0]
+        self.assertEqual(len(session["session_id"]), 8)
+        self.assertEqual(session["session_id"], "named-se")
+
 
 class TestDashboardHTTP(unittest.TestCase):
     """Integration test: start server and make HTTP requests."""
@@ -215,6 +260,14 @@ class TestHTMLTemplate(unittest.TestCase):
     def test_template_is_valid_html(self):
         self.assertIn("<!DOCTYPE html>", HTML_TEMPLATE)
         self.assertIn("</html>", HTML_TEMPLATE)
+
+    def test_template_renders_session_name_when_set(self):
+        """The sessions-table renderer must branch on session_name presence."""
+        self.assertIn("s.session_name", HTML_TEMPLATE)
+        self.assertIn("session-name", HTML_TEMPLATE)
+
+    def test_csv_export_includes_session_name(self):
+        self.assertIn("Session Name", HTML_TEMPLATE)
 
     def test_template_has_esc_function(self):
         """Verify XSS protection is present (PR #10)."""

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import sqlite3
 import tempfile
 import threading
@@ -196,6 +197,21 @@ class TestDashboardHTTP(unittest.TestCase):
 
 
 class TestHTMLTemplate(unittest.TestCase):
+    def _extract_js_function(self, name):
+        signature = f"function {name}("
+        start = HTML_TEMPLATE.index(signature)
+        brace_start = HTML_TEMPLATE.index("{", start)
+        depth = 0
+        for idx in range(brace_start, len(HTML_TEMPLATE)):
+            char = HTML_TEMPLATE[idx]
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    return HTML_TEMPLATE[start:idx + 1]
+        self.fail(f"Could not extract JavaScript function {name}")
+
     def test_template_is_valid_html(self):
         self.assertIn("<!DOCTYPE html>", HTML_TEMPLATE)
         self.assertIn("</html>", HTML_TEMPLATE)
@@ -227,6 +243,41 @@ class TestHTMLTemplate(unittest.TestCase):
         """Peak-hour set covers UTC 12–17 (Mon–Fri 05:00–11:00 PT)."""
         self.assertIn('PEAK_HOURS_UTC', HTML_TEMPLATE)
         self.assertIn('[12, 13, 14, 15, 16, 17]', HTML_TEMPLATE)
+
+    def test_range_filter_uses_bounds_for_all_filtered_data(self):
+        """Regression for GH#88: range filtering must not reference undefined variables."""
+        apply_filter = self._extract_js_function("applyFilter")
+
+        bounds_decl = apply_filter.index("const { start, end } = getRangeBounds(selectedRange);")
+        daily_filter = apply_filter.index("rawData.daily_by_model.filter")
+        sessions_filter = apply_filter.index("rawData.sessions_all.filter")
+        hourly_filter = apply_filter.index("rawData.hourly_by_model || []")
+
+        self.assertLess(bounds_decl, daily_filter)
+        self.assertLess(bounds_decl, sessions_filter)
+        self.assertLess(bounds_decl, hourly_filter)
+        self.assertNotRegex(apply_filter, r"\bcutoff\b")
+        for filter_start in [daily_filter, sessions_filter, hourly_filter]:
+            filter_block = apply_filter[filter_start:filter_start + 180]
+            self.assertIn("!start", filter_block)
+            self.assertIn("!end", filter_block)
+
+    def test_template_handles_each_supported_range(self):
+        """Each selectable range needs UI, URL parsing, labels, ticks, and bounds support."""
+        expected_ranges = ["7d", "30d", "90d", "all"]
+        get_bounds = self._extract_js_function("getRangeBounds")
+        read_url_range = self._extract_js_function("readURLRange")
+
+        for range_name in expected_ranges:
+            self.assertIn(f'data-range="{range_name}"', HTML_TEMPLATE)
+            self.assertIn("VALID_RANGES.includes(p)", read_url_range)
+            self.assertRegex(HTML_TEMPLATE, rf"RANGE_LABELS\s*=\s*\{{[^}}]*'{re.escape(range_name)}':")
+            self.assertRegex(HTML_TEMPLATE, rf"RANGE_TICKS\s*=\s*\{{[^}}]*'{re.escape(range_name)}':")
+
+        self.assertIn("range === 'all'", get_bounds)
+        self.assertIn("range === '7d' ? 7", get_bounds)
+        self.assertIn("range === '30d' ? 30", get_bounds)
+        self.assertIn(": 90", get_bounds)
 
 
 class TestPricingParity(unittest.TestCase):

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -10,7 +10,24 @@ from pathlib import Path
 from scanner import (
     get_db, init_db, project_name_from_cwd, parse_jsonl_file,
     aggregate_sessions, upsert_sessions, insert_turns, scan,
+    resolve_session_name,
 )
+
+
+def _make_custom_title_record(session_id="sess-1", title="my-session"):
+    return json.dumps({
+        "type": "custom-title",
+        "customTitle": title,
+        "sessionId": session_id,
+    })
+
+
+def _make_agent_name_record(session_id="sess-1", name="my-agent"):
+    return json.dumps({
+        "type": "agent-name",
+        "agentName": name,
+        "sessionId": session_id,
+    })
 
 
 class TestProjectNameFromCwd(unittest.TestCase):
@@ -643,6 +660,227 @@ class TestParseJsonlFileLineCount(unittest.TestCase):
             pass
         _, _, line_count = parse_jsonl_file(path)
         self.assertEqual(line_count, 0)
+
+
+class TestResolveSessionName(unittest.TestCase):
+    def test_prefers_custom_title(self):
+        self.assertEqual(resolve_session_name("ct", "an"), "ct")
+
+    def test_falls_back_to_agent_name(self):
+        self.assertEqual(resolve_session_name(None, "an"), "an")
+
+    def test_empty_custom_title_falls_back(self):
+        self.assertEqual(resolve_session_name("", "an"), "an")
+
+    def test_both_empty_returns_none(self):
+        self.assertIsNone(resolve_session_name(None, None))
+        self.assertIsNone(resolve_session_name("", ""))
+
+
+class TestSessionNameParsing(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def _write_jsonl(self, filename, lines):
+        path = os.path.join(self.tmpdir, filename)
+        with open(path, "w") as f:
+            for line in lines:
+                f.write(line + "\n")
+        return path
+
+    def test_custom_title_captured(self):
+        path = self._write_jsonl("t.jsonl", [
+            _make_user_record(),
+            _make_custom_title_record(title="clip-research"),
+            _make_assistant_record(),
+        ])
+        metas, _, _ = parse_jsonl_file(path)
+        sessions = aggregate_sessions(metas, [])
+        self.assertEqual(sessions[0]["session_name"], "clip-research")
+
+    def test_agent_name_fallback(self):
+        path = self._write_jsonl("t.jsonl", [
+            _make_user_record(),
+            _make_agent_name_record(name="helper-bot"),
+            _make_assistant_record(),
+        ])
+        metas, _, _ = parse_jsonl_file(path)
+        sessions = aggregate_sessions(metas, [])
+        self.assertEqual(sessions[0]["session_name"], "helper-bot")
+
+    def test_custom_title_preferred_over_agent_name(self):
+        path = self._write_jsonl("t.jsonl", [
+            _make_user_record(),
+            _make_agent_name_record(name="agent-first"),
+            _make_custom_title_record(title="chosen-title"),
+            _make_assistant_record(),
+        ])
+        metas, _, _ = parse_jsonl_file(path)
+        sessions = aggregate_sessions(metas, [])
+        self.assertEqual(sessions[0]["session_name"], "chosen-title")
+
+    def test_last_custom_title_wins_after_rename(self):
+        path = self._write_jsonl("t.jsonl", [
+            _make_user_record(),
+            _make_custom_title_record(title="first-name"),
+            _make_assistant_record(),
+            _make_custom_title_record(title="renamed"),
+        ])
+        metas, _, _ = parse_jsonl_file(path)
+        sessions = aggregate_sessions(metas, [])
+        self.assertEqual(sessions[0]["session_name"], "renamed")
+
+    def test_no_rename_records_yields_none(self):
+        path = self._write_jsonl("t.jsonl", [
+            _make_user_record(),
+            _make_assistant_record(),
+        ])
+        metas, _, _ = parse_jsonl_file(path)
+        sessions = aggregate_sessions(metas, [])
+        self.assertIsNone(sessions[0]["session_name"])
+
+    def test_empty_custom_title_ignored(self):
+        path = self._write_jsonl("t.jsonl", [
+            _make_user_record(),
+            _make_custom_title_record(title="real-title"),
+            _make_custom_title_record(title=""),  # empty — must not clobber
+            _make_assistant_record(),
+        ])
+        metas, _, _ = parse_jsonl_file(path)
+        sessions = aggregate_sessions(metas, [])
+        self.assertEqual(sessions[0]["session_name"], "real-title")
+
+
+class TestSessionNameIntegration(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.projects_dir = Path(self.tmpdir) / "projects" / "user" / "proj"
+        self.projects_dir.mkdir(parents=True)
+        self.db_path = Path(self.tmpdir) / "usage.db"
+        self.filepath = self.projects_dir / "sess-1.jsonl"
+
+    def test_session_name_persisted_on_scan(self):
+        with open(self.filepath, "w") as f:
+            f.write(_make_user_record(session_id="sess-1") + "\n")
+            f.write(_make_custom_title_record(session_id="sess-1", title="clip-research") + "\n")
+            f.write(_make_assistant_record(session_id="sess-1", message_id="msg-1") + "\n")
+
+        scan(projects_dir=self.projects_dir.parent.parent,
+             db_path=self.db_path, verbose=False)
+
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT session_name FROM sessions WHERE session_id='sess-1'").fetchone()
+        conn.close()
+        self.assertEqual(row["session_name"], "clip-research")
+
+    def test_session_name_preserved_when_incremental_scan_has_no_rename(self):
+        """Appending assistant turns without rename records must not blank out session_name."""
+        # Initial scan: session gets named
+        with open(self.filepath, "w") as f:
+            f.write(_make_user_record(session_id="sess-1") + "\n")
+            f.write(_make_custom_title_record(session_id="sess-1", title="keep-me") + "\n")
+            f.write(_make_assistant_record(session_id="sess-1", message_id="msg-1") + "\n")
+        scan(projects_dir=self.projects_dir.parent.parent,
+             db_path=self.db_path, verbose=False)
+
+        # Append a turn without any rename record
+        import time
+        time.sleep(0.05)
+        with open(self.filepath, "a") as f:
+            f.write(_make_assistant_record(session_id="sess-1", message_id="msg-2",
+                                           timestamp="2026-04-08T10:05:00Z") + "\n")
+        scan(projects_dir=self.projects_dir.parent.parent,
+             db_path=self.db_path, verbose=False)
+
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT session_name FROM sessions WHERE session_id='sess-1'").fetchone()
+        conn.close()
+        self.assertEqual(row["session_name"], "keep-me")
+
+    def test_session_name_updates_on_rename_during_incremental_scan(self):
+        """A rename captured in appended lines should replace the stored session_name."""
+        with open(self.filepath, "w") as f:
+            f.write(_make_user_record(session_id="sess-1") + "\n")
+            f.write(_make_custom_title_record(session_id="sess-1", title="old-name") + "\n")
+            f.write(_make_assistant_record(session_id="sess-1", message_id="msg-1") + "\n")
+        scan(projects_dir=self.projects_dir.parent.parent,
+             db_path=self.db_path, verbose=False)
+
+        import time
+        time.sleep(0.05)
+        with open(self.filepath, "a") as f:
+            f.write(_make_custom_title_record(session_id="sess-1", title="new-name") + "\n")
+            f.write(_make_assistant_record(session_id="sess-1", message_id="msg-2",
+                                           timestamp="2026-04-08T10:05:00Z") + "\n")
+        scan(projects_dir=self.projects_dir.parent.parent,
+             db_path=self.db_path, verbose=False)
+
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT session_name FROM sessions WHERE session_id='sess-1'").fetchone()
+        conn.close()
+        self.assertEqual(row["session_name"], "new-name")
+
+
+class TestSessionNameMigration(unittest.TestCase):
+    """Existing DBs without a session_name column should be upgraded by init_db."""
+
+    def setUp(self):
+        self.tmpfile = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmpfile.close()
+        self.db_path = Path(self.tmpfile.name)
+
+    def tearDown(self):
+        os.unlink(self.db_path)
+
+    def test_session_name_column_added_to_existing_db(self):
+        # Seed a pre-migration schema (no session_name column). Mirror the legacy
+        # shape init_db expects to find so the upgrade path (ALTER TABLE) runs.
+        conn = sqlite3.connect(self.db_path)
+        conn.executescript("""
+            CREATE TABLE sessions (
+                session_id TEXT PRIMARY KEY,
+                project_name TEXT,
+                first_timestamp TEXT,
+                last_timestamp TEXT,
+                git_branch TEXT,
+                total_input_tokens INTEGER DEFAULT 0,
+                total_output_tokens INTEGER DEFAULT 0,
+                total_cache_read INTEGER DEFAULT 0,
+                total_cache_creation INTEGER DEFAULT 0,
+                model TEXT,
+                turn_count INTEGER DEFAULT 0
+            );
+            CREATE TABLE turns (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT,
+                timestamp TEXT,
+                model TEXT,
+                input_tokens INTEGER DEFAULT 0,
+                output_tokens INTEGER DEFAULT 0,
+                cache_read_tokens INTEGER DEFAULT 0,
+                cache_creation_tokens INTEGER DEFAULT 0,
+                tool_name TEXT,
+                cwd TEXT
+            );
+            CREATE TABLE processed_files (
+                path TEXT PRIMARY KEY,
+                mtime REAL,
+                lines INTEGER
+            );
+        """)
+        conn.commit()
+        cols_before = [r[1] for r in conn.execute("PRAGMA table_info(sessions)").fetchall()]
+        self.assertNotIn("session_name", cols_before)
+        conn.close()
+
+        conn = get_db(self.db_path)
+        init_db(conn)
+        cols = [r["name"] for r in conn.execute("PRAGMA table_info(sessions)").fetchall()]
+        self.assertIn("session_name", cols)
+        conn.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #56. Surfaces the session name set via Claude Code's `/rename` command in the dashboard, instead of only the `session_id`.

- Scanner parses `customTitle` / `agentName` from JSONL records (the records emitted by `/rename`) and stores per-session as `session_name`
- `customTitle` is preferred over `agentName`; last non-empty value per session wins; empty strings are ignored so a later blank record can't clobber an earlier rename
- Incremental scans preserve the stored name when the appended slice contains no rename records (`COALESCE(NULLIF(?, ''), session_name)`)
- Schema: new `sessions.session_name` column with `ALTER TABLE` migration in `init_db` for existing DBs; dashboard query falls back to `NULL` if migration hasn't yet run
- UI: sessions table shows `name (id…)` when a name is set, falls back to the truncated ID otherwise; CSV export now has both `Session ID` and `Session Name` columns

## Test plan

- [x] `python -m unittest discover -s tests -v` — 103 tests pass (17 new)
- [x] End-to-end sanity: scan a synthesised JSONL with a `custom-title` record, confirm `get_dashboard_data` returns the name
- [x] Migration path: existing pre-column DB gets `session_name` added via `init_db`
- [x] Incremental scan with no rename preserves the prior name; a new rename overwrites it

🤖 Generated with [Claude Code](https://claude.com/claude-code)