### PR TITLE
feat: add Homebrew formula and install docs (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add Homebrew formula at `Formula/claude-usage.rb` and install instructions; `claude-usage` is now installable on macOS/Linux without `git clone` (#46)
+
 ## 2026-04-09
 
 - Fix token counts inflated ~2x by deduplicating streaming events that share the same message ID

--- a/Formula/claude-usage.rb
+++ b/Formula/claude-usage.rb
@@ -1,0 +1,28 @@
+class ClaudeUsage < Formula
+  desc "Token, cost, and session dashboard for Claude Code usage"
+  homepage "https://github.com/phuryn/claude-usage"
+  url "https://github.com/phuryn/claude-usage/archive/af507cd42447eafcb44ac6ae31b25fae1dbbc8a6.tar.gz"
+  version "0.1.0"
+  sha256 "4554728852f58b254a75a317d6d99f6b9cc7ac4c2f60c21590b41abd2aa88467"
+  license "MIT"
+  head "https://github.com/phuryn/claude-usage.git", branch: "main"
+
+  depends_on "python@3.13"
+
+  def install
+    libexec.install "cli.py", "scanner.py", "dashboard.py"
+
+    (bin/"claude-usage").write <<~EOS
+      #!/bin/bash
+      exec "#{Formula["python@3.13"].opt_bin}/python3" "#{libexec}/cli.py" "$@"
+    EOS
+    chmod 0755, bin/"claude-usage"
+  end
+
+  test do
+    output = shell_output("#{bin}/claude-usage")
+    assert_match "Claude Code Usage Dashboard", output
+    assert_match "scan", output
+    assert_match "dashboard", output
+  end
+end

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Captures usage from:
 
 No `pip install`, no virtual environment, no build step.
 
+### macOS / Linux (Homebrew)
+```
+brew install --formula https://raw.githubusercontent.com/phuryn/claude-usage/main/Formula/claude-usage.rb
+claude-usage dashboard
+```
+
+After install, the `claude-usage` command is on your `PATH` and accepts the same subcommands as `python cli.py` (`scan`, `today`, `stats`, `dashboard`).
+
 ### Windows
 ```
 git clone https://github.com/phuryn/claude-usage
@@ -45,7 +53,7 @@ cd claude-usage
 python cli.py dashboard
 ```
 
-### macOS / Linux
+### macOS / Linux (clone)
 ```
 git clone https://github.com/phuryn/claude-usage
 cd claude-usage
@@ -56,7 +64,7 @@ python3 cli.py dashboard
 
 ## Usage
 
-> On macOS/Linux, use `python3` instead of `python` in all commands below.
+> On macOS/Linux, use `python3` instead of `python` in all commands below. If you installed via Homebrew, replace `python cli.py` with `claude-usage`.
 
 ```
 # Scan JSONL files and populate the database (~/.claude/usage.db)
@@ -122,3 +130,4 @@ Costs are calculated using **Anthropic API pricing as of April 2026** ([claude.c
 | `scanner.py` | Parses JSONL transcripts, writes to `~/.claude/usage.db` |
 | `dashboard.py` | HTTP server + single-page HTML/JS dashboard |
 | `cli.py` | `scan`, `today`, `stats`, `dashboard` commands |
+| `Formula/claude-usage.rb` | Homebrew formula — install with `brew install --formula <raw-url>` |


### PR DESCRIPTION
## Summary

Closes #46.

Adds a Homebrew formula at `Formula/claude-usage.rb` so Mac/Linux users can install with one command instead of cloning:

```
brew install --formula https://raw.githubusercontent.com/phuryn/claude-usage/main/Formula/claude-usage.rb
claude-usage dashboard
```

The formula:
- Installs `cli.py`, `scanner.py`, `dashboard.py` to `libexec/`
- Drops a `claude-usage` shim into `bin/` that invokes `python@3.13` against the installed `cli.py`
- Has a `head` block so `brew install --HEAD claude-usage` tracks `main`
- Includes a `test do` block that runs `claude-usage` with no args and checks the help output

No changes to runtime code — all 84 tests still pass.

## Notes for the maintainer

- **`url`/`sha256` are pinned to current `main` (`af507cd`).** When you cut a release tag, bump `version` in the formula, swap the archive URL to the tag, and refresh `sha256` (`shasum -a 256` of the tarball, or `brew fetch`).
- **For nicer UX** (`brew install phuryn/tap/claude-usage`), publish the formula in a `phuryn/homebrew-tap` repo or submit it to homebrew-core once there's a tagged release. The formula in this repo serves as the source of truth either way.
- **Why `python@3.13`?** It's currently Homebrew's default Python 3 keg. The project requires Python 3.8+; this just pins to a known-good version. Easy to bump as Homebrew moves.

## Test plan

- [x] `ruby -c Formula/claude-usage.rb` — Syntax OK
- [x] Simulated install locally (copied files to a temp `libexec`, wrote the shim, ran with no args) — prints USAGE, exits 0
- [x] `pytest tests/` — 84 passed
- [ ] Reviewer with macOS: `brew install --formula ./Formula/claude-usage.rb` and `brew test claude-usage`