### PR TITLE
fix: use `start` instead of undefined `cutoff` in hourly filter

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
## Bug

In `applyFilter()`, the hourly data filter referenced `cutoff` — a variable that was never defined in scope. `applyFilter()` destructures `{ start, end }` from `getRangeBounds()`, so the correct variable is `start`.

```js
// before (broken)
const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
  selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
);

// after
const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
  selectedModels.has(r.model) && (!start || r.day >= start)
);
```

## Impact

- **ReferenceError** in the browser console on every filter change
- **Hourly chart silently shows all-time data** regardless of the selected date range, because `cutoff` evaluated as `undefined` (falsy), making the date guard always pass

## Fix

One-line: replace `cutoff` with `start`.