### PR TITLE
fix: replace undefined `cutoff` with `start` in hourly filter

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
`applyFilter()` used an undeclared `cutoff` variable when filtering hourly data, causing a ReferenceError that aborted the function before any stats, charts, or tables could render.