### PR TITLE
fix: undefined cutoff variable breaks dashboard rendering

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
## Summary
- The hourly aggregation filter in `applyFilter()` referenced an undeclared variable `cutoff`, causing a `ReferenceError` that silently aborted the entire function
- No stats cards, charts, or tables were rendered on the dashboard despite the API returning valid data
- Replaced `cutoff` with the `start`/`end` range bounds already used by all other filters in the same function

## Root Cause
In `dashboard.py` line 745, the hourly filter used `(!cutoff || r.day >= cutoff)` but `cutoff` was never defined in `applyFilter()`. This was likely a leftover from a refactor that introduced the `getRangeBounds()` system returning `{ start, end }`. The daily filter (line 662) and session filter (line 691) were updated to use `start`/`end`, but the hourly filter was missed.

## Fix
```diff
- selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+ selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
```

This also adds the missing `end` bound check, which is needed for bounded ranges like "This Month" and "Prev Month".

## Test plan
- [x] All 91 existing tests pass
- [x] Launched dashboard with `python cli.py dashboard` and confirmed stats, charts, and tables render correctly
- [ ] Verify date range filters (This Week, This Month, Prev Month, 7d, 30d, 90d, All) work on the hourly chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)