### PR TITLE
fix: use ThreadingHTTPServer so slow /api/data does not block other requests

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -5,7 +5,7 @@ dashboard.py - Local web dashboard served on localhost:8080.
 import json
 import os
 import sqlite3
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
 from datetime import datetime
 
@@ -1290,7 +1290,7 @@ class DashboardHandler(BaseHTTPRequestHandler):
 def serve(host=None, port=None):
     host = host or os.environ.get("HOST", "localhost")
     port = port or int(os.environ.get("PORT", "8080"))
-    server = HTTPServer((host, port), DashboardHandler)
+    server = ThreadingHTTPServer((host, port), DashboardHandler)
     print(f"Dashboard running at http://{host}:{port}")
     print("Press Ctrl+C to stop.")
     try:


### PR DESCRIPTION
Closes #78

## What

Swap `HTTPServer` for the stdlib `ThreadingHTTPServer` so the dashboard can serve more than one request at a time.

```diff
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 ...
-server = HTTPServer((host, port), DashboardHandler)
+server = ThreadingHTTPServer((host, port), DashboardHandler)
```

No new dependencies (`ThreadingHTTPServer` is in `http.server` since Python 3.7, which the README already requires).

## Why

Detailed motivation in #78. Short version: `/api/data` takes ~50–200 ms on real DBs and the single-threaded server queues every other request behind it, which:

* makes the page auto-refresh stall during user interaction,
* breaks parallel HTTP healthchecks (Docker `HEALTHCHECK` in particular flips to `unhealthy`),
* lets Chrome land on a cached error page when concurrent fetches time out.

## Safety

* `get_dashboard_data()` opens and closes its own `sqlite3.connect()`, so concurrent reads are fine.
* `do_POST /api/rescan` does delete + rebuild on the DB; concurrent rescans were already a footgun in the single-threaded version (the user can POST /api/rescan twice while one is running) and the threaded version is no worse.
* No daemon-thread shutdown surprises — `ThreadingHTTPServer` defaults `daemon_threads=True`, so Ctrl-C still exits cleanly.

## Verification

With the unpatched server, this hangs the second request until the first finishes:

```bash
curl --max-time 30 http://localhost:8080/api/data >/dev/null &
sleep 0.05
time curl --max-time 5 http://localhost:8080/
```

With the patch, both return immediately.