### PR TITLE
fix: strip query string before routing so bookmarkable URLs do not 404

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -6,6 +6,7 @@ import json
 import os
 import sqlite3
 from http.server import HTTPServer, BaseHTTPRequestHandler
+from urllib.parse import urlparse
 from pathlib import Path
 from datetime import datetime
 
@@ -1242,13 +1243,17 @@ class DashboardHandler(BaseHTTPRequestHandler):
         pass
 
     def do_GET(self):
-        if self.path in ("/", "/index.html"):
+        # self.path includes the query string, but every URL the UI emits has
+        # one (e.g. "/?range=all"); compare the bare path so bookmarkable
+        # URLs don't fall through to 404.
+        path = urlparse(self.path).path
+        if path in ("/", "/index.html"):
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
             self.wfile.write(HTML_TEMPLATE.encode("utf-8"))
 
-        elif self.path == "/api/data":
+        elif path == "/api/data":
             data = get_dashboard_data()
             body = json.dumps(data).encode("utf-8")
             self.send_response(200)
@@ -1262,7 +1267,8 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self.end_headers()
 
     def do_POST(self):
-        if self.path == "/api/rescan":
+        path = urlparse(self.path).path
+        if path == "/api/rescan":
             # Full rebuild: delete DB and rescan from scratch.
             # Pass DB_PATH / DEFAULT_PROJECTS_DIRS explicitly so tests that
             # patch the module globals are honored (scan's defaults are

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -166,6 +166,23 @@ class TestDashboardHTTP(unittest.TestCase):
             self.assertEqual(resp.status, 200)
             self.assertIn("text/html", resp.headers["Content-Type"])
 
+    def test_index_with_query_string_returns_html(self):
+        # Regression: ?range=... and ?models=... must not 404. The dashboard
+        # itself rewrites the URL with these params via history.replaceState,
+        # so anything that reloads or bookmarks the page hits this path.
+        for qs in ("?range=all", "?range=30d&models=claude-opus-4-7"):
+            with urllib.request.urlopen(f"http://127.0.0.1:{self.port}/{qs}") as resp:
+                self.assertEqual(resp.status, 200)
+                self.assertIn(b"Claude Code Usage Dashboard", resp.read())
+
+    def test_api_data_with_query_string(self):
+        # /api/data is fetched without query parameters today, but the route
+        # should be tolerant if any are tacked on (e.g. cache-busting).
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{self.port}/api/data?_=cachebust"
+        ) as resp:
+            self.assertEqual(resp.status, 200)
+
     def test_api_data_returns_json(self):
         url = f"http://127.0.0.1:{self.port}/api/data"
         with urllib.request.urlopen(url) as resp:


### PR DESCRIPTION
Closes #80

## What

* `do_GET` / `do_POST` route on `urlparse(self.path).path` instead of the raw `self.path`. URLs like `/?range=all` and `/?range=30d&models=...` now hit the index handler instead of falling through to 404.
* Adds `urlparse` import (stdlib).
* Two regression tests in `tests/test_dashboard.py` cover both `/?range=...` and `/api/data?_=cachebust`.

```diff
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from urllib.parse import urlparse

     def do_GET(self):
-        if self.path in ("/", "/index.html"):
+        path = urlparse(self.path).path
+        if path in ("/", "/index.html"):
             ...
-        elif self.path == "/api/data":
+        elif path == "/api/data":
```

## Why

#80 has the full motivation. Short version: the dashboard rewrites the URL with `?range=` via `history.replaceState`, so the first range-button click and any subsequent reload would break.

## Verification

```bash
$ curl -o /dev/null -w "%%{http_code}\n" "http://127.0.0.1:8080/?range=all"
# before: 404
# after:  200
```

`python -m unittest tests.test_dashboard -v` — all 25 tests pass, including the two new ones.