### PR TITLE
fix: streaming dedup correctness + dashboard server hardening

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -5,7 +5,7 @@ dashboard.py - Local web dashboard served on localhost:8080.
 import json
 import os
 import sqlite3
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
 from datetime import datetime
 
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 
@@ -1242,13 +1242,14 @@ class DashboardHandler(BaseHTTPRequestHandler):
         pass
 
     def do_GET(self):
-        if self.path in ("/", "/index.html"):
+        path = self.path.split("?", 1)[0]
+        if path in ("/", "/index.html"):
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
             self.wfile.write(HTML_TEMPLATE.encode("utf-8"))
 
-        elif self.path == "/api/data":
+        elif path == "/api/data":
             data = get_dashboard_data()
             body = json.dumps(data).encode("utf-8")
             self.send_response(200)
@@ -1262,14 +1263,18 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self.end_headers()
 
     def do_POST(self):
-        if self.path == "/api/rescan":
-            # Full rebuild: delete DB and rescan from scratch.
+        path, _, query = self.path.partition("?")
+        if path == "/api/rescan":
+            # Default: incremental scan (fast, non-destructive).
+            # Opt-in full rebuild with ?full=1 — useful when pricing or
+            # parsing logic changes and historical rows need to be redone.
             # Pass DB_PATH / DEFAULT_PROJECTS_DIRS explicitly so tests that
             # patch the module globals are honored (scan's defaults are
             # frozen at def time and would otherwise target the real paths).
             import scanner
             db_path = DB_PATH
-            if db_path.exists():
+            full = "full=1" in query
+            if full and db_path.exists():
                 db_path.unlink()
             result = scanner.scan(
                 db_path=db_path,
@@ -1290,8 +1295,13 @@ class DashboardHandler(BaseHTTPRequestHandler):
 def serve(host=None, port=None):
     host = host or os.environ.get("HOST", "localhost")
     port = port or int(os.environ.get("PORT", "8080"))
-    server = HTTPServer((host, port), DashboardHandler)
+    ThreadingHTTPServer.allow_reuse_address = True
+    server = ThreadingHTTPServer((host, port), DashboardHandler)
     print(f"Dashboard running at http://{host}:{port}")
+    if host not in ("localhost", "127.0.0.1", "::1"):
+        print(f"  WARNING: bound to {host} — no authentication. "
+              "Anyone reachable on this interface can read your project history "
+              "and trigger /api/rescan.")
     print("Press Ctrl+C to stop.")
     try:
         server.serve_forever()

--- a/scanner.py
+++ b/scanner.py
@@ -300,8 +300,13 @@ def upsert_sessions(conn, sessions):
 
 
 def insert_turns(conn, turns):
+    # INSERT OR REPLACE: if a later record arrives for the same message_id
+    # (Claude streams multiple records per message — the last has the final
+    # usage tallies), overwrite the earlier partial row. INSERT OR IGNORE
+    # would lock in stale partial counts when the streaming boundary fell
+    # between two incremental scans.
     conn.executemany("""
-        INSERT OR IGNORE INTO turns
+        INSERT OR REPLACE INTO turns
             (session_id, timestamp, model, input_tokens, output_tokens,
              cache_read_tokens, cache_creation_tokens, tool_name, cwd, message_id)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)


### PR DESCRIPTION
Two independent bug-fix commits, each cleanly scoped to a single file. Happy to split into separate PRs if you'd prefer.

## 1. `scanner.py` — streaming dedup loses final usage tallies on incremental scans

Claude Code emits multiple JSONL records per assistant message (streaming); only the last record contains the final `usage.*_tokens` values. `parse_jsonl_file` already dedups by keeping the last record per `message.id`, which is correct on a single full parse.

But on incremental scans, if the streaming records straddle the previous scan's `processed_files.lines` boundary:

1. Scan 1 reads up to line N mid-stream → inserts a row with **partial** counts for `message.id = X`.
2. Claude Code finishes streaming, writes the final record at line N+k.
3. Scan 2 reads from N+1 → sees the final record → tries to `INSERT` → unique index on `message_id` triggers `INSERT OR IGNORE` to silently drop it.

Net result: the partial counts are locked in forever. Session totals, daily charts, hourly charts and cost estimates all inherit the wrong values. The end-of-`scan()` recompute fixes session totals only by re-summing `turns`, which by then still holds the partial row.

Switching the statement to `INSERT OR REPLACE` makes last-write-wins, which matches the existing dedup intent. The unique index ensures only one row per `message_id` survives, and the recompute then propagates correct totals to `sessions`.

## 2. `dashboard.py` — three small bugs + server hardening

* `do_GET` / `do_POST`: strip the query string from `self.path` before matching. Reloading at e.g. `/?range=week` previously fell through to the 404 branch because `self.path` includes the query string. The JS sets that query via `history.replaceState`, so any user with a non-default range would see a 404 on refresh.
* `applyFilter()`: the hourly-data filter referenced an undefined `cutoff` variable (the daily filter above it correctly uses `start`/`end` from `getRangeBounds(...)`). This threw `ReferenceError` on every load, blocking all chart rendering.
* `HTTPServer` → `ThreadingHTTPServer` with `allow_reuse_address`: long rescans no longer freeze GETs, and the port frees instantly on Ctrl+C instead of sitting in TIME_WAIT.
* Startup warning when bound to a non-loopback host — the dashboard has no auth, so `HOST=0.0.0.0` exposes project history (and `/api/rescan`) to any LAN peer.
* `/api/rescan` now defaults to an incremental scan; the destructive full rebuild is opt-in via `?full=1`. The UI button keeps using the default, which is the right behavior for a routine refresh; a full rebuild remains available for cases like pricing-table changes.

## Test plan

- [x] `python3 -m unittest discover tests` — 91/91 pass on this branch
- [x] Manual: load `/?range=week`, `/?range=90d`, hard-refresh — charts render, no JS errors
- [x] Manual: trigger Rescan from the UI while another tab is open at `/` — both stay responsive
- [x] Manual: incremental scan picks up appended turns without duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)