### PR TITLE
fix: dashboard blank due to undefined 'cutoff' variable in applyFilter

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
## Summary

- `applyFilter()` filtered hourly data using `cutoff`, a variable that is never defined anywhere in scope
- This throws a `ReferenceError` at runtime, which is silently swallowed by the `try-catch` in `loadData()`, causing the entire dashboard to render blank
- Fixed by replacing `cutoff` with `start` (and adding `end` for symmetry), which are already in scope from `getRangeBounds(selectedRange)` — consistent with how daily and session data are filtered

## Test plan

- [ ] Run `python3 cli.py dashboard` and confirm charts, stats, and tables render correctly
- [ ] Open browser devtools console and confirm no `ReferenceError` on load
- [ ] Verify date range filter buttons correctly filter the hourly chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)