### PR TITLE
fix(dashboard): replace undefined `cutoff` var that blanks the UI

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
## Summary

`applyFilter()` in `dashboard.py` references an undefined variable `cutoff` when filtering the hourly activity data. This throws a `ReferenceError` on first load, which is silently swallowed by the `try/catch` in `loadData()` — so the entire dashboard renders blank with no error visible to the user (only a `console.error` in DevTools).

```js
// dashboard.py L745 (before)
const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
  selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
);
```

`cutoff` is not defined anywhere in the file — only this single reference exists.

## Root cause

A merge regression between two recently merged PRs:

- #43 (`feat/date-range-filters`) refactored the old `cutoff` variable into the `start`/`end` pair returned by `getRangeBounds()`.
- #72 (`feat/hourly-activity-chart`) was developed in parallel and added the hourly filter line above using the pre-refactor `cutoff` name.

When both landed, the hourly filter kept the stale variable name and broke the dashboard. No test caught it because the failure path is `applyFilter throws → caught → silent`.

## Fix

One-line change: align the hourly filter with the daily filter pattern used a few lines above:

```js
const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
  selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
);
```

## Test plan

- [x] Reproduced the blank dashboard locally on `main` (Windows 11, Python 3.x). DevTools console showed `ReferenceError: cutoff is not defined`.
- [x] After the fix, dashboard renders all sections correctly: stats panel, daily chart, hourly chart, by-model table, projects table.
- [x] Verified all date-range buttons (week / month / 7d / 30d / 90d / all) and the model filter work as expected.

## Suggested follow-up (not in this PR)

Consider letting the error in `loadData()`'s `catch` surface to the user (e.g. render an inline error banner) so the next regression of this kind doesn't silently produce a blank UI.