### PR TITLE
Fix ReferenceError: cutoff is not defined (blank charts)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
## Summary

`applyFilter()` in `dashboard.py` references an undefined variable `cutoff` when filtering `hourly_by_model`:

```js
const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
  selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
);
```

`cutoff` was never defined in this scope — `getRangeBounds()` returns `{start, end}`, and the daily filter directly above (line ~538) already uses those names correctly.

The result is a `ReferenceError` that aborts `applyFilter()` before any of the four `new Chart(...)` calls run. The dashboard loads, the API returns data, but every chart stays blank — only the header, filter bar, and table headings render.

## Fix

Match the daily filter and use `start` / `end` from `getRangeBounds()`. This also correctly handles ranges that have an end date (`week`, `month`, `prev-month`).

```diff
- selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+ selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
```

## Test plan

- [x] Reproduce on `main`: blank charts, `ReferenceError: cutoff is not defined` in console
- [x] After patch: all four charts render (Daily Token Usage, Average Hourly Distribution, By Model, Top Projects)
- [x] Verified `30d` range; the new `end` clause correctly bounds finite ranges (`week`, `month`, `prev-month`)