### PR TITLE
fix: resolve undefined 'cutoff' variable in hourly filtering

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
## Description

Fixes a ReferenceError in the dashboard's `applyFilter()` function where the hourly aggregation filter was referencing an undefined variable `cutoff`.

## The Issue

When filtering hourly data by date range, the code at line 745 was using an undefined variable `cutoff`:

```javascript
const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
  selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
);
```

This caused a `ReferenceError: cutoff is not defined` error when the `applyFilter()` function was called.

## The Fix

Changed the filter to use the proper `start` and `end` variables that are already defined in the function scope, matching the pattern used elsewhere in the same function:

```javascript
const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
  selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
);
```

## Test Plan

- [x] Open the dashboard in a browser
- [x] Change the date range filter
- [x] Verify no console errors occur
- [x] Verify hourly chart updates correctly with the selected date range