### PR TITLE
fix: hourly chart now respects start/end date range

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
The hourly filter referenced an undefined `cutoff` variable, so `(!cutoff || ...)` was always truthy — the hourly chart was never filtered by date. Use `start`/`end` from getRangeBounds(), matching the daily filter at line 662.