### PR TITLE
fix: replace undefined `cutoff` with `start`/`end` in hourly filter

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
The hourly filter in applyFilter() referenced `cutoff` which is not defined in that scope. The date-range refactor introduced `start`/`end` via getRangeBounds() but this one filter line was not updated, causing a ReferenceError that prevented all charts from rendering.