### PR TITLE
fix: change default port to 57832 and fix hourly filter ReferenceError

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -369,7 +369,7 @@ def cmd_dashboard(projects_dir=None, host=None, port=None):
     from dashboard import serve
 
     host = host or os.environ.get("HOST", "localhost")
-    port = int(port or os.environ.get("PORT", "8080"))
+    port = int(port or os.environ.get("PORT", "57832"))
 
     def open_browser():
         time.sleep(1.0)

--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 
@@ -1289,7 +1289,7 @@ class DashboardHandler(BaseHTTPRequestHandler):
 
 def serve(host=None, port=None):
     host = host or os.environ.get("HOST", "localhost")
-    port = port or int(os.environ.get("PORT", "8080"))
+    port = port or int(os.environ.get("PORT", "57832"))
     server = HTTPServer((host, port), DashboardHandler)
     print(f"Dashboard running at http://{host}:{port}")
     print("Press Ctrl+C to stop.")


### PR DESCRIPTION
## What changed

- Default port changed from 8080 to 57832 in cli.py and dashboard.py. Less commonly occupied, overridable via PORT env var.
- Fixed ReferenceError: cutoff is not defined in applyFilter() (dashboard.py). The variable cutoff was a stale artifact from an earlier refactor — rest of function already used start/end from getRangeBounds(). Replaced with (!start || r.day >= start) && (!end || r.day <= end).

## Why

The cutoff bug caused a JS error on every filter call, silently breaking all dashboard data rendering — charts and tables showed empty despite data existing in DB.

## Testing

Ran python cli.py dashboard — dashboard loads and renders data correctly across all date range selections.