### PR TITLE
fix(dashboard): resolve ReferenceError in hourly filter

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
Fixed a bug where the undefined variable `cutoff` was being used in the hourly aggregation filter, causing a JavaScript crash that left the entire dashboard empty. Switched to using `start` and `end` bounds.