### PR TITLE
fix: resolve ReferenceError cutoff is not defined in applyFilter

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
## Problem

After opening the dashboard, no data was displayed and the browser console showed:
```
ReferenceError: cutoff is not defined
    at applyFilter
```

## Root cause

The `hourly_by_model` filter inside `applyFilter()` still referenced the old `cutoff` variable, which was removed when the function was refactored to use `{ start, end }` from `getRangeBounds()`. All other filters in the same function already used `start`/`end` correctly.

## Fix

Replace the stale `cutoff` reference with `start` and `end` to match the existing pattern used for `filteredDaily` and `filteredSessions`.