### PR TITLE
fix: HTTP router 404 on query params + missing first_timestamp in incremental scan

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 
@@ -1242,13 +1242,15 @@ class DashboardHandler(BaseHTTPRequestHandler):
         pass
 
     def do_GET(self):
-        if self.path in ("/", "/index.html"):
+        from urllib.parse import urlparse
+        parsed_path = urlparse(self.path).path
+        if parsed_path in ("/", "/index.html"):
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
             self.wfile.write(HTML_TEMPLATE.encode("utf-8"))
 
-        elif self.path == "/api/data":
+        elif parsed_path == "/api/data":
             data = get_dashboard_data()
             body = json.dumps(data).encode("utf-8")
             self.send_response(200)

--- a/scanner.py
+++ b/scanner.py
@@ -419,6 +419,8 @@ def scan(projects_dir=None, projects_dirs=None, db_path=DB_PATH, verbose=True):
                             meta = new_session_metas[session_id]
                             if timestamp and (not meta["last_timestamp"] or timestamp > meta["last_timestamp"]):
                                 meta["last_timestamp"] = timestamp
+                            if timestamp and (not meta["first_timestamp"] or timestamp < meta["first_timestamp"]):
+                                meta["first_timestamp"] = timestamp
 
                         if rtype == "assistant":
                             msg = record.get("message", {})


### PR DESCRIPTION
## Problems

### 1. Dashboard returns 404 when URL has query parameters

Opening `http://localhost:8080/?range=month&models=claude-sonnet-4-6` returned a 404 because `do_GET` compared `self.path` directly against `"/"`. When the browser appends query parameters, `self.path` becomes `/?range=...` which never matched.

**Fix:** Parse the path with `urlparse` before routing so query parameters are stripped.

### 2. `first_timestamp` never updated in incremental scans

When new lines are appended to an existing JSONL file, the incremental scan updated `last_timestamp` correctly but never updated `first_timestamp` — even if a newly seen record had an earlier timestamp. This caused session duration (`duration_min`) to be underestimated.

**Fix:** Mirror the `last_timestamp` update logic for `first_timestamp` using `<` instead of `>`.