### PR TITLE
  Fix dashboard hourly filter ReferenceError

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -228,6 +228,14 @@ class TestHTMLTemplate(unittest.TestCase):
         self.assertIn('PEAK_HOURS_UTC', HTML_TEMPLATE)
         self.assertIn('[12, 13, 14, 15, 16, 17]', HTML_TEMPLATE)
 
+    def test_hourly_filter_uses_selected_range_bounds(self):
+        """Hourly dashboard rows use the same selected date bounds as daily rows."""
+        self.assertNotIn("cutoff", HTML_TEMPLATE)
+        self.assertGreaterEqual(
+            HTML_TEMPLATE.count("(!start || r.day >= start) && (!end || r.day <= end)"),
+            2,
+        )
+
 
 class TestPricingParity(unittest.TestCase):
     """Verify CLI and dashboard pricing tables stay in sync."""


### PR DESCRIPTION
  ## Summary
  - Fixes a dashboard crash caused by `cutoff` being referenced in `applyFilter()`
  - Updates hourly aggregation to use the same `start` / `end` range bounds as daily and session filtering
  - Adds a regression test to ensure the old `cutoff` reference does not return

  ## Bug
  Running:

  ```bash
  python cli.py dashboard

  could produce this browser console error:

  ReferenceError: cutoff is not defined
      at applyFilter

  This happened because the hourly filter referenced cutoff, but applyFilter() defines date bounds as start and end.

  ## Testing

  python -m unittest discover

  Result:

  Ran 92 tests
  OK