### PR TITLE
fix: replace undefined cutoff with start/end range in hourly filter

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
## Summary
- Dashboard threw `ReferenceError: cutoff is not defined` at `dashboard.py:622` (line 745 in source), breaking `applyFilter()` and stopping the page from rendering whenever `loadData()` fired.
- The reference was a leftover from the range-bounds refactor: the daily and session filters were migrated to use `{ start, end }` from `getRangeBounds()`, but the hourly filter still referenced the old `cutoff` variable.
- Replaces the broken filter with the same `start` / `end` bounds the sibling filters use. As a side effect this also fixes a silent data-mismatch: under the broken code the `(!cutoff || ...)` short-circuit was always truthy, so the hourly chart was rendering the full timeline instead of the selected range — meaning the "Average Hourly Distribution" chart never honored upper bounds like `prev-month`, `month`, or `week`.

## Repro (before fix)
1. Open the dashboard.
2. Browser console shows:
   ```
   ReferenceError: cutoff is not defined
       at (index):622:38
       at Array.filter (<anonymous>)
       at applyFilter ((index):621:53)
       at loadData ((index):1095:5)
   ```
3. Charts and tables do not populate.

## Test plan
- [x] Reload dashboard — no console error, charts and tables render.
- [x] Switch between ranges (`week`, `month`, `prev-month`, `7d`, `30d`, `90d`, `all`) — hourly chart updates in sync with the daily / model / project charts.
- [x] Confirm `grep -n cutoff dashboard.py` returns no matches.