### PR TITLE
fix: replace undefined `cutoff` variable in applyFilter hourly filter

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
## Summary

- `cutoff` was used in the `applyFilter` function to filter hourly data, but was never defined in scope
- This caused a `ReferenceError` at runtime that silently aborted `applyFilter` before any charts, stat cards, or tables were rendered
- Fixed by replacing `cutoff` with `start` and `end`, which are already computed earlier in the same function and used correctly for the daily chart filter

## Test plan

- [ ] Launch dashboard with `python3 cli.py dashboard`
- [ ] Verify charts (Daily Token Usage, Average Hourly Distribution, By Model, Top Projects) render correctly
- [ ] Verify stat cards (Sessions, Turns, Input/Output Tokens, Est. Cost) appear
- [ ] Verify range buttons (7d, 30d, 90d, etc.) correctly filter all charts including the hourly one

🤖 Generated with [Claude Code](https://claude.com/claude-code)