### PR TITLE
fix: use start/end bounds in hourly filter instead of undefined cutoff

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
## Summary

The dashboard throws a JS error on every load:

```
(index):1097 ReferenceError: cutoff is not defined
    at (index):622:38
    at Array.filter (<anonymous>)
    at applyFilter ((index):621:53)
    at loadData ((index):1095:5)
```

The hourly aggregation filter in `applyFilter()` references a `cutoff` variable that doesn't exist in scope — it looks like a leftover from an earlier iteration. The surrounding daily/sessions filters use `start` / `end` from `getRangeBounds(selectedRange)`. This PR switches the hourly filter to the same bounds so it matches the rest of the code and the error goes away.

- One-line change in `dashboard.py`
- Hourly data is now range-filtered consistently with the daily and sessions filters (both lower and upper bound)

## Test plan

- [ ] Open the dashboard — no console error on load
- [ ] Switch ranges (week, month, prev-month, 7d, 30d, 90d, all) — Average Hourly Distribution chart updates and only includes hours from the selected range
- [ ] Toggle Local / UTC — hourly chart re-buckets correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)