### PR TITLE
fix: replace stale cutoff with start/end in hourly filter

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -228,6 +228,16 @@ class TestHTMLTemplate(unittest.TestCase):
         self.assertIn('PEAK_HOURS_UTC', HTML_TEMPLATE)
         self.assertIn('[12, 13, 14, 15, 16, 17]', HTML_TEMPLATE)
 
+    def test_hourly_filter_uses_start_end_not_cutoff(self):
+        """Hourly filter must use start/end like the daily filter.
+
+        Regression guard: the date-range refactor renamed `cutoff` to
+        start/end; a stray `cutoff` reference in the hourly filter would
+        throw ReferenceError inside applyFilter() and break every chart.
+        """
+        self.assertNotIn("r.day >= cutoff", HTML_TEMPLATE)
+        self.assertNotIn("r.day <= cutoff", HTML_TEMPLATE)
+
 
 class TestPricingParity(unittest.TestCase):
     """Verify CLI and dashboard pricing tables stay in sync."""


### PR DESCRIPTION
## Summary

`applyFilter()` in `dashboard.py` referenced an undefined `cutoff` variable when building `hourlySrc`, throwing `ReferenceError` and preventing every chart, total, and table on the dashboard from rendering.

`cutoff` was leftover from before [#43](https://github.com/phuryn/claude-usage/pull/43) introduced `start`/`end` date-range bounds; [#72](https://github.com/phuryn/claude-usage/pull/72) (hourly activity chart) was written against the older single-cutoff pattern and merged without the rename.

## Change

- Mirror the daily filter pattern so hourly rows are gated by both `start` and `end`:
  ```js
  // before
  (!cutoff || r.day >= cutoff)
  // after
  (!start || r.day >= start) && (!end || r.day <= end)
  ```
- Add a regression test (`test_hourly_filter_uses_start_end_not_cutoff`) that fails if the stale name returns.

## Test plan

- [x] New test fails before the fix, passes after
- [x] `python3 -m unittest tests.test_dashboard` — all 24 tests pass
- [x] Restart `python3 cli.py dashboard` and reload the page — Daily Token Usage, Average Hourly Distribution, By Model, Top Projects by Tokens, and Cost by Model all render