### PR TITLE
Add live limits widget, session health, multi-metric efficiency grader, and per-message live session view

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,0 +1,35 @@
+# Disclaimer
+
+This is an **unofficial, community-maintained fork** of [phuryn/claude-usage](https://github.com/phuryn/claude-usage). It is **not affiliated with, endorsed by, or sponsored by Anthropic, PBC**.
+
+## Trademarks
+
+"Claude" and "Anthropic" are trademarks of Anthropic, PBC. Their use in this project is purely descriptive — to identify the product whose local usage logs this tool reads. No endorsement is implied.
+
+## Plan budgets are approximations
+
+Anthropic does not publish exact token caps for Pro, Max 5×, or Max 20× plans. The values in `limits.py` (`PLAN_BUDGETS`) are best-effort estimates calibrated against observed usage. They may be wrong. Do not rely on them for billing, capacity planning, or any decision with real financial impact.
+
+If your real session is throttled before the bar shows full — or runs longer than the bar predicts — that is expected. The bar is a directional indicator, not a contract.
+
+## API endpoint probing
+
+`limits.py` attempts to read plan metadata from undocumented Anthropic endpoints (`/api/oauth/profile`, `/api/account`) using your locally-stored OAuth token. These calls:
+
+- Are wrapped in try/except and fail silently if the endpoints change or refuse the request
+- Make at most one request per 24 hours (cached at `~/.claude/usage-plan-cache.json`)
+- Are skipped entirely if `CLAUDE_USAGE_PLAN` is set in your environment
+
+If you prefer zero network calls to Anthropic, set `CLAUDE_USAGE_PLAN=pro` (or your plan) in your shell profile or launchd plist.
+
+## No data leaves your machine
+
+This tool reads only local files (`~/.claude/projects/*.jsonl`) and writes only to a local SQLite database (`~/.claude/usage.db`). The HTTP server binds to `localhost` by default. No telemetry. No analytics. No remote logging.
+
+## Cost estimates
+
+Costs shown are calculated using public Anthropic API list pricing. If you use Claude Code via a Pro or Max subscription, your actual cost is the flat subscription fee — the displayed "API equivalent cost" is informational only.
+
+## No warranty
+
+Provided as-is under the MIT License. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
 [![claude-code](https://img.shields.io/badge/claude--code-black?style=flat-square)](https://claude.ai/code)
 
+> **Fork notice:** This is a fork of [phuryn/claude-usage](https://github.com/phuryn/claude-usage) with added features:
+> - Live limits widget (weekly stacked bar, per-model breakdown, plan auto-detect)
+> - Session Health card with new-session recommendations
+> - Multi-metric Token Efficiency grader (Cache Hit + Reuse Ratio + Output Discipline + Cost Efficiency)
+> - Per-message live session view (click row → see each prompt with token totals)
+> - Session titles extracted from first user prompt (replaces opaque project IDs)
+> - Local timezone auto-detect (was UTC-only)
+> - Noise filter: skill invocations / system reminders excluded from live view
+> - Bug fix: `cutoff` → `start`/`end` ReferenceError that killed charts
+
 **Pro and Max subscribers get a progress bar. This gives you the full picture.**
 
 Claude Code writes detailed usage logs locally — token counts, models, sessions, projects — regardless of your plan. This dashboard reads those logs and turns them into charts and cost estimates. Works on API, Pro, and Max plans.
@@ -119,10 +129,62 @@ Costs are calculated using **Anthropic API pricing as of April 2026** ([claude.c
 
 ---
 
+## Fork features
+
+### Live limits widget
+Top banner shows a **weekly all-models stacked bar** (Opus orange, Sonnet blue, Haiku green) with per-model breakdown beneath: `opus X% · 5.5M  sonnet Y% · 550k  haiku Z%`.
+
+Plan auto-detection order:
+1. macOS keychain → OAuth token → `api.anthropic.com/api/oauth/profile` (undocumented, may return None)
+2. `CLAUDE_USAGE_PLAN` env var
+3. Default `pro`
+
+Plan budgets (approximate — Anthropic does not publish exact caps):
+
+| Plan | Session 5h tokens | Weekly all-models |
+|------|-------------------|-------------------|
+| `pro` | 613k | 23M |
+| `max_5x` | 3.07M | 115M |
+| `max_20x` | 12.26M | 460M |
+
+Override via `CLAUDE_USAGE_PLAN=max_5x python cli.py dashboard` or `/api/limits?plan=max_5x`.
+
+Cache-read tokens weighted `0.1×` in billable totals to match Anthropic's cost-equivalent counting (~25% deviation in calibration).
+
+### Session Health card
+Heuristic warnings — "start new session" surfaces when any of:
+- Context > 150k tokens
+- Cache hit rate < 40%
+- Avg > 60k tokens/turn
+- Session age > 3h
+
+States: `ok` / `info` / `warn` with colored border.
+
+### Token Efficiency grader
+A/B/C/D grade from weighted formula:
+- Cache Hit 40%
+- Reuse Ratio 25%
+- Cost Efficiency 20%
+- Output Discipline 15%
+
+`?` info button in chart header reveals the formula. Recalcs every 30s with `/api/data`, respects date-range filter.
+
+### Per-message live view
+Click any session row → polls `/api/session/<id>` every 5s. Each user prompt shows token totals (input / output / cache_read / cache_creation), model, turn count, and tools used. Skill invocations and system reminders are filtered out so the list shows real human turns only.
+
+### New endpoints
+- `GET /api/limits?plan=<pro|max_5x|max_20x>` — weekly + session 5h budgets, plan, used/remaining
+- `GET /api/session/<id>` — per-message breakdown for a session
+
+Server uses `ThreadingHTTPServer` so concurrent `/api/data` + `/api/limits` calls don't block.
+
+---
+
 ## Files
 
 | File | Purpose |
 |------|---------|
 | `scanner.py` | Parses JSONL transcripts, writes to `~/.claude/usage.db` |
 | `dashboard.py` | HTTP server + single-page HTML/JS dashboard |
+| `limits.py` | Plan detection, session 5h window, rolling weekly budgets |
 | `cli.py` | `scan`, `today`, `stats`, `dashboard` commands |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
 [![claude-code](https://img.shields.io/badge/claude--code-black?style=flat-square)](https://claude.ai/code)
 
-> **Fork notice:** This is a fork of [phuryn/claude-usage](https://github.com/phuryn/claude-usage) with added features:
+> **Fork notice:** This is an unofficial fork of [phuryn/claude-usage](https://github.com/phuryn/claude-usage). Not affiliated with Anthropic. See [DISCLAIMER.md](DISCLAIMER.md). Added features:
 > - Live limits widget (weekly stacked bar, per-model breakdown, plan auto-detect)
 > - Session Health card with new-session recommendations
 > - Multi-metric Token Efficiency grader (Cache Hit + Reuse Ratio + Output Discipline + Cost Efficiency)

--- a/dashboard.py
+++ b/dashboard.py
@@ -4,12 +4,119 @@ dashboard.py - Local web dashboard served on localhost:8080.
 
 import json
 import os
+import re
+import glob
 import sqlite3
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import HTTPServer, ThreadingHTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 DB_PATH = Path.home() / ".claude" / "usage.db"
+
+
+def _detect_tz_offset_hours():
+    """Auto-detect system timezone offset in hours. Override with env TZ_OFFSET_HOURS."""
+    env = os.environ.get("TZ_OFFSET_HOURS")
+    if env not in (None, ""):
+        try:
+            return int(env)
+        except ValueError:
+            pass
+    try:
+        off = datetime.now().astimezone().utcoffset()
+        if off is None:
+            return 0
+        return int(off.total_seconds() // 3600)
+    except Exception:
+        return 0
+
+
+TZ_OFFSET_HOURS = _detect_tz_offset_hours()
+TZ_NAME = datetime.now().astimezone().tzname() or f"UTC{TZ_OFFSET_HOURS:+d}"
+SQL_TZ_SHIFT = f"'+{TZ_OFFSET_HOURS} hours'" if TZ_OFFSET_HOURS >= 0 else f"'{TZ_OFFSET_HOURS} hours'"
+
+PROJECTS_DIRS = [
+    Path.home() / ".claude" / "projects",
+    Path.home() / "Library" / "Developer" / "Xcode" / "CodingAssistant" / "ClaudeAgentConfig" / "projects",
+]
+
+
+def _shift_iso(ts, hours=TZ_OFFSET_HOURS):
+    if not ts:
+        return ""
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        return (dt + timedelta(hours=hours)).strftime("%Y-%m-%dT%H:%M:%S")
+    except Exception:
+        return ts
+
+
+_TITLE_CACHE = {}  # session_id -> (mtime, title, project_path, jsonl_path)
+
+
+def _find_session_jsonl(session_id):
+    for d in PROJECTS_DIRS:
+        if not d.exists():
+            continue
+        for p in d.rglob(f"{session_id}.jsonl"):
+            return p
+    return None
+
+
+def _extract_title(jsonl_path):
+    try:
+        with open(jsonl_path, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                try:
+                    d = json.loads(line)
+                except Exception:
+                    continue
+                if d.get("type") != "user":
+                    continue
+                msg = d.get("message")
+                if not isinstance(msg, dict) or msg.get("role") != "user":
+                    continue
+                c = msg.get("content")
+                text = None
+                if isinstance(c, str):
+                    text = c
+                elif isinstance(c, list):
+                    for it in c:
+                        if isinstance(it, dict) and it.get("type") == "text":
+                            text = it.get("text")
+                            break
+                if not text:
+                    continue
+                t = text.strip()
+                if t.startswith("<") or t.startswith("Caveat:") or t.startswith("[Request"):
+                    continue
+                t = " ".join(t.split())
+                return t[:80] + ("..." if len(t) > 80 else "")
+    except Exception:
+        pass
+    return ""
+
+
+def get_session_titles(session_ids):
+    out = {}
+    for sid in session_ids:
+        p = _find_session_jsonl(sid)
+        if not p:
+            out[sid] = ""
+            continue
+        try:
+            mtime = p.stat().st_mtime
+        except OSError:
+            out[sid] = ""
+            continue
+        cached = _TITLE_CACHE.get(sid)
+        if cached and cached[0] == mtime:
+            out[sid] = cached[1]
+        else:
+            title = _extract_title(p)
+            _TITLE_CACHE[sid] = (mtime, title, str(p.parent), str(p))
+            out[sid] = title
+    return out
 
 
 def get_dashboard_data(db_path=DB_PATH):
@@ -29,9 +136,9 @@ def get_dashboard_data(db_path=DB_PATH):
     all_models = [r["model"] for r in model_rows]
 
     # ── Daily per-model, ALL history (client filters by range) ────────────────
-    daily_rows = conn.execute("""
+    daily_rows = conn.execute(f"""
         SELECT
-            substr(timestamp, 1, 10)   as day,
+            substr(datetime(timestamp, {SQL_TZ_SHIFT}), 1, 10)   as day,
             COALESCE(model, 'unknown') as model,
             SUM(input_tokens)          as input,
             SUM(output_tokens)         as output,
@@ -55,10 +162,10 @@ def get_dashboard_data(db_path=DB_PATH):
 
     # ── Hourly per-day per-model (client filters by range + TZ-shifts) ────────
     # Timestamps are ISO8601 UTC (e.g. "2026-04-08T09:30:00Z"); chars 12-13 = hour.
-    hourly_rows = conn.execute("""
+    hourly_rows = conn.execute(f"""
         SELECT
-            substr(timestamp, 1, 10)                  as day,
-            CAST(substr(timestamp, 12, 2) AS INTEGER) as hour,
+            substr(datetime(timestamp, {SQL_TZ_SHIFT}), 1, 10)                  as day,
+            CAST(substr(datetime(timestamp, {SQL_TZ_SHIFT}), 12, 2) AS INTEGER) as hour,
             COALESCE(model, 'unknown')                as model,
             SUM(output_tokens)                        as output,
             COUNT(*)                                  as turns
@@ -88,6 +195,8 @@ def get_dashboard_data(db_path=DB_PATH):
     """).fetchall()
 
     sessions_all = []
+    raw_ids = [r["session_id"] for r in session_rows]
+    titles = get_session_titles(raw_ids[:50])  # title lookup limited to recent 50
     for r in session_rows:
         try:
             t1 = datetime.fromisoformat(r["first_timestamp"].replace("Z", "+00:00"))
@@ -95,12 +204,15 @@ def get_dashboard_data(db_path=DB_PATH):
             duration_min = round((t2 - t1).total_seconds() / 60, 1)
         except Exception:
             duration_min = 0
+        last_shifted = _shift_iso(r["last_timestamp"])
         sessions_all.append({
             "session_id":    r["session_id"][:8],
+            "session_id_full": r["session_id"],
+            "title":         titles.get(r["session_id"], ""),
             "project":       r["project_name"] or "unknown",
             "branch":        r["git_branch"] or "",
-            "last":          (r["last_timestamp"] or "")[:16].replace("T", " "),
-            "last_date":     (r["last_timestamp"] or "")[:10],
+            "last":          last_shifted[:16].replace("T", " "),
+            "last_date":     last_shifted[:10],
             "duration_min":  duration_min,
             "model":         r["model"] or "unknown",
             "turns":         r["turn_count"] or 0,
@@ -112,12 +224,178 @@ def get_dashboard_data(db_path=DB_PATH):
 
     conn.close()
 
+    # Project label map: prefer cleaner names. For opaque project IDs (UUIDs/paths
+    # ending in random hex), use the most recent session title.
+    project_labels = {}
+    import re as _re
+    uuid_re = _re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", _re.I)
+    for s in sessions_all:
+        proj = s["project"]
+        if proj in project_labels:
+            continue
+        looks_opaque = (
+            uuid_re.search(proj) is not None
+            or proj.count("/") > 1
+            or proj == "unknown"
+        )
+        if looks_opaque and s.get("title"):
+            project_labels[proj] = s["title"][:50]
+        else:
+            # Use basename of path
+            base = proj.rstrip("/").split("/")[-1] if "/" in proj else proj
+            project_labels[proj] = base or proj
+
     return {
         "all_models":      all_models,
         "daily_by_model":  daily_by_model,
         "hourly_by_model": hourly_by_model,
         "sessions_all":    sessions_all,
+        "project_labels":  project_labels,
+        "tz_name":         TZ_NAME,
+        "tz_offset_hours": TZ_OFFSET_HOURS,
         "generated_at":    datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+    }
+
+
+def _is_real_user_message(msg):
+    """True if message is an actual human prompt (not tool_result)."""
+    if not isinstance(msg, dict):
+        return False
+    if msg.get("role") != "user":
+        return False
+    c = msg.get("content")
+    if isinstance(c, str):
+        return c.strip() != ""
+    if isinstance(c, list):
+        for it in c:
+            if isinstance(it, dict):
+                if it.get("type") == "tool_result":
+                    return False
+                if it.get("type") == "text" and it.get("text", "").strip():
+                    return True
+        return False
+    return False
+
+
+def _msg_text(msg):
+    c = msg.get("content") if isinstance(msg, dict) else None
+    if isinstance(c, str):
+        return c
+    if isinstance(c, list):
+        parts = []
+        for it in c:
+            if isinstance(it, dict) and it.get("type") == "text":
+                parts.append(it.get("text", ""))
+        return " ".join(parts)
+    return ""
+
+
+_NOISE_TAG_RE = re.compile(
+    r"<(command-message|command-name|command-args|command-stdout|command-output|"
+    r"local-command-stdout|local-command-output|system-reminder|bash-input|bash-stdout|"
+    r"bash-stderr|user-prompt-submit-hook)\b[^>]*>.*?</\1>",
+    re.DOTALL,
+)
+
+
+def _is_noise_prompt(text):
+    """True if prompt body is only Claude Code wrapper tags (skill invocations, hook injections, system reminders)."""
+    stripped = _NOISE_TAG_RE.sub("", text or "").strip()
+    return stripped == ""
+
+
+def parse_session_messages(jsonl_path):
+    """Group turns by user message. Returns list of {prompt, timestamp, input, output, cache_read, cache_creation, model, turn_count}."""
+    groups = []
+    current = None
+    try:
+        with open(jsonl_path, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                try:
+                    d = json.loads(line)
+                except Exception:
+                    continue
+                t = d.get("type")
+                ts = d.get("timestamp", "")
+                msg = d.get("message")
+                if t == "user" and _is_real_user_message(msg):
+                    text = _msg_text(msg).strip()
+                    if _is_noise_prompt(text):
+                        # Skill invocations / system reminders aren't real user turns —
+                        # let following assistant tokens accumulate on prior prompt.
+                        continue
+                    text = " ".join(text.split())
+                    current = {
+                        "prompt": text[:200] + ("..." if len(text) > 200 else ""),
+                        "full_prompt": text,
+                        "timestamp": _shift_iso(ts),
+                        "input": 0,
+                        "output": 0,
+                        "cache_read": 0,
+                        "cache_creation": 0,
+                        "model": "",
+                        "turn_count": 0,
+                        "tools": [],
+                    }
+                    groups.append(current)
+                elif t == "assistant" and current is not None and isinstance(msg, dict):
+                    usage = msg.get("usage") or {}
+                    current["input"] += usage.get("input_tokens", 0) or 0
+                    current["output"] += usage.get("output_tokens", 0) or 0
+                    current["cache_read"] += usage.get("cache_read_input_tokens", 0) or 0
+                    current["cache_creation"] += usage.get("cache_creation_input_tokens", 0) or 0
+                    current["turn_count"] += 1
+                    if not current["model"]:
+                        current["model"] = msg.get("model", "") or ""
+                    c = msg.get("content")
+                    if isinstance(c, list):
+                        for it in c:
+                            if isinstance(it, dict) and it.get("type") == "tool_use":
+                                name = it.get("name", "")
+                                if name and name not in current["tools"]:
+                                    current["tools"].append(name)
+    except Exception:
+        pass
+    return groups
+
+
+def get_session_live(session_id, db_path=DB_PATH):
+    if not db_path.exists():
+        return {"error": "Database not found"}
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    # Resolve full id from prefix
+    row = conn.execute(
+        "SELECT session_id, project_name, model, turn_count, first_timestamp, last_timestamp, "
+        "total_input_tokens, total_output_tokens, total_cache_read, total_cache_creation, git_branch "
+        "FROM sessions WHERE session_id = ? OR session_id LIKE ? LIMIT 1",
+        (session_id, session_id + "%"),
+    ).fetchone()
+    if not row:
+        conn.close()
+        return {"error": f"Session not found: {session_id}"}
+    full_id = row["session_id"]
+    conn.close()
+    jsonl = _find_session_jsonl(full_id)
+    messages = parse_session_messages(jsonl) if jsonl else []
+    titles = get_session_titles([full_id])
+    return {
+        "session_id": full_id,
+        "title": titles.get(full_id, ""),
+        "project": row["project_name"] or "unknown",
+        "branch": row["git_branch"] or "",
+        "model": row["model"] or "unknown",
+        "turn_count": row["turn_count"] or 0,
+        "first": _shift_iso(row["first_timestamp"]),
+        "last": _shift_iso(row["last_timestamp"]),
+        "totals": {
+            "input": row["total_input_tokens"] or 0,
+            "output": row["total_output_tokens"] or 0,
+            "cache_read": row["total_cache_read"] or 0,
+            "cache_creation": row["total_cache_creation"] or 0,
+        },
+        "messages": messages,
+        "generated_at": (datetime.utcnow() + timedelta(hours=TZ_OFFSET_HOURS)).strftime("%Y-%m-%d %H:%M:%S"),
     }
 
 
@@ -147,6 +425,33 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
   header .meta { color: var(--muted); font-size: 12px; }
   #rescan-btn { background: var(--card); border: 1px solid var(--border); color: var(--muted); padding: 4px 12px; border-radius: 6px; cursor: pointer; font-size: 12px; margin-top: 4px; }
   #rescan-btn:hover { color: var(--text); border-color: var(--accent); }
+
+  /* Live limits banner */
+  #limits-banner { background: var(--card); border-bottom: 1px solid var(--border); padding: 12px 24px; display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; align-items: stretch; }
+  .limit-card { border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; position: relative; }
+  .limit-card .lc-head { display: flex; justify-content: space-between; align-items: baseline; font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 6px; }
+  .limit-card .lc-pct { color: var(--text); font-weight: 600; font-size: 12px; letter-spacing: 0; text-transform: none; }
+  .limit-card .lc-bar { height: 8px; background: rgba(255,255,255,0.05); border-radius: 4px; overflow: hidden; display: flex; }
+  .limit-card .lc-fill { height: 100%; width: 0%; background: var(--green); transition: width 0.4s ease, background 0.4s; }
+  .limit-card .lc-fill.warn { background: #f59e0b; }
+  .limit-card .lc-fill.danger { background: #ef4444; }
+  .limit-card .lc-seg { height: 100%; transition: width 0.4s ease; }
+  .limit-card .lc-foot { display: flex; justify-content: space-between; font-size: 11px; color: var(--muted); margin-top: 6px; }
+  .limit-card .lc-foot strong { color: var(--text); font-weight: 600; }
+  .lc-models { display: flex; gap: 10px; margin-top: 6px; font-size: 10px; color: var(--muted); flex-wrap: wrap; }
+  .lc-models .lc-model { display: inline-flex; align-items: center; gap: 4px; }
+  .lc-models .lc-swatch { width: 8px; height: 8px; border-radius: 2px; display: inline-block; }
+  #lc-health { padding: 10px 12px; border: 1px solid var(--border); border-radius: 8px; font-size: 12px; line-height: 1.4; }
+  #lc-health.health-ok { border-color: rgba(74,222,128,0.3); }
+  #lc-health.health-info { border-color: #f59e0b; background: rgba(245,158,11,0.06); }
+  #lc-health.health-warn { border-color: #ef4444; background: rgba(239,68,68,0.08); }
+  #lc-health .lc-head { display: flex; justify-content: space-between; font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 6px; }
+  #lc-health .lc-msg { color: var(--text); }
+  #lc-health.health-ok .lc-msg { color: var(--muted); }
+  #lc-health .lc-stats { font-size: 10px; color: var(--muted); margin-top: 6px; display: flex; gap: 10px; flex-wrap: wrap; }
+  #limits-meta { padding: 6px 24px 0; font-size: 11px; color: var(--muted); display: flex; justify-content: space-between; gap: 12px; flex-wrap: wrap; align-items: center; }
+  #plan-select { background: var(--card); border: 1px solid var(--border); color: var(--text); border-radius: 4px; padding: 2px 6px; font-size: 11px; }
+  .lc-disabled { opacity: 0.5; }
   #rescan-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
   #filter-bar { background: var(--card); border-bottom: 1px solid var(--border); padding: 10px 24px; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
@@ -227,6 +532,35 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
   <button id="rescan-btn" onclick="triggerRescan()" title="Rebuild the database from scratch by re-scanning all JSONL files. Use if data looks stale or costs seem wrong.">&#x21bb; Rescan</button>
 </header>
 
+<div id="limits-meta">
+  <div>
+    Plan:
+    <select id="plan-select" onchange="onPlanOverride()">
+      <option value="">Auto-detect</option>
+      <option value="pro">Pro</option>
+      <option value="max_5x">Max 5×</option>
+      <option value="max_20x">Max 20×</option>
+    </select>
+    <span id="plan-source" style="margin-left:8px"></span>
+  </div>
+  <div title="Only weekly all-models usage syncs reliably with Claude Settings → Usage. 5h session and Claude Design are computed server-side by Anthropic with an undocumented formula and can't be reproduced from local JSONL.">
+    Weekly all-models only · session &amp; Claude Design not trackable locally
+  </div>
+</div>
+<div id="limits-banner">
+  <div class="limit-card" id="lc-weekly">
+    <div class="lc-head"><span>Weekly · All Models</span><span class="lc-pct">—</span></div>
+    <div class="lc-bar"><div class="lc-fill"></div></div>
+    <div class="lc-foot"><span class="lc-used">— / —</span><span class="lc-reset">7d rolling</span></div>
+    <div class="lc-models" id="lc-weekly-models"></div>
+  </div>
+  <div id="lc-health" class="health-ok">
+    <div class="lc-head"><span>Session Health</span><span id="health-session-id" style="text-transform:none;letter-spacing:0">—</span></div>
+    <div class="lc-msg" id="health-msg">Loading…</div>
+    <div class="lc-stats" id="health-stats"></div>
+  </div>
+</div>
+
 <div id="filter-bar">
   <div class="filter-label">Models</div>
   <div id="model-checkboxes"></div>
@@ -267,34 +601,37 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
       <div class="chart-wrap"><canvas id="chart-hourly"></canvas></div>
     </div>
     <div class="chart-card">
-      <h2>By Model</h2>
-      <div class="chart-wrap"><canvas id="chart-model"></canvas></div>
+      <h2>Token Efficiency
+        <button onclick="toggleEffHelp()" title="How is this graded?" style="background:none;border:1px solid var(--border);color:var(--muted);width:18px;height:18px;border-radius:50%;font-size:11px;cursor:pointer;margin-left:6px;line-height:1;padding:0">?</button>
+        <span id="efficiency-grade" style="float:right;font-size:14px"></span>
+      </h2>
+      <div id="eff-help" style="display:none;background:rgba(255,255,255,0.03);border:1px solid var(--border);border-radius:6px;padding:10px;margin:6px 0;font-size:11px;color:var(--muted);line-height:1.5">
+        <strong style="color:var(--text)">Grade = weighted score of 4 sub-metrics over selected range:</strong>
+        <ul style="margin:6px 0 0 16px;padding:0">
+          <li><strong>Cache Hit Rate (40%):</strong> cache_read / (cache_read + cache_creation + fresh_input). Higher = more reuse.</li>
+          <li><strong>Reuse Ratio (25%):</strong> cache_read / cache_creation. 4×+ = full credit. &lt;1× = wasted writes.</li>
+          <li><strong>Output Discipline (15%):</strong> penalty if output / total_input &gt; ~30%. Chatty responses hurt.</li>
+          <li><strong>Cost Efficiency (20%):</strong> 1 - actual_cost / no_cache_cost. Uses Anthropic prices (cache_read 0.1×, cache_write 1.25×).</li>
+        </ul>
+        <div style="margin-top:6px">Updates on every dashboard refresh (every 30s). Pinned to the date range filter above — change the range, score recalcs.</div>
+      </div>
+      <div class="chart-wrap"><canvas id="chart-efficiency"></canvas></div>
     </div>
     <div class="chart-card">
       <h2>Top Projects by Tokens</h2>
       <div class="chart-wrap"><canvas id="chart-project"></canvas></div>
     </div>
   </div>
-  <div class="table-card">
-    <div class="section-title">Cost by Model</div>
-    <table>
-      <thead><tr>
-        <th>Model</th>
-        <th class="sortable" onclick="setModelSort('turns')">Turns <span class="sort-icon" id="msort-turns"></span></th>
-        <th class="sortable" onclick="setModelSort('input')">Input <span class="sort-icon" id="msort-input"></span></th>
-        <th class="sortable" onclick="setModelSort('output')">Output <span class="sort-icon" id="msort-output"></span></th>
-        <th class="sortable" onclick="setModelSort('cache_read')">Cache Read <span class="sort-icon" id="msort-cache_read"></span></th>
-        <th class="sortable" onclick="setModelSort('cache_creation')">Cache Creation <span class="sort-icon" id="msort-cache_creation"></span></th>
-        <th class="sortable" onclick="setModelSort('cost')">Est. Cost <span class="sort-icon" id="msort-cost"></span></th>
-      </tr></thead>
-      <tbody id="model-cost-body"></tbody>
-    </table>
+  <div class="table-card" id="efficiency-card">
+    <div class="section-title">Efficiency Breakdown</div>
+    <div id="efficiency-body" style="padding:14px;display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:14px"></div>
   </div>
   <div class="table-card">
-    <div class="section-header"><div class="section-title">Recent Sessions</div><button class="export-btn" onclick="exportSessionsCSV()" title="Export all filtered sessions to CSV">&#x2913; CSV</button></div>
+    <div class="section-header"><div class="section-title">Recent Sessions <span style="color:var(--muted);font-weight:400;font-size:11px">(click row to watch live)</span></div><button class="export-btn" onclick="exportSessionsCSV()" title="Export all filtered sessions to CSV">&#x2913; CSV</button></div>
     <table>
       <thead><tr>
         <th>Session</th>
+        <th>Title</th>
         <th>Project</th>
         <th class="sortable" onclick="setSessionSort('last')">Last Active <span class="sort-icon" id="sort-icon-last"></span></th>
         <th class="sortable" onclick="setSessionSort('duration_min')">Duration <span class="sort-icon" id="sort-icon-duration_min"></span></th>
@@ -305,6 +642,32 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
         <th class="sortable" onclick="setSessionSort('cost')">Est. Cost <span class="sort-icon" id="sort-icon-cost"></span></th>
       </tr></thead>
       <tbody id="sessions-body"></tbody>
+    </table>
+  </div>
+
+  <div class="table-card" id="live-session-card" style="display:none">
+    <div class="section-header">
+      <div class="section-title">Live Session: <span id="live-title" style="color:var(--muted);font-weight:400"></span></div>
+      <div>
+        <span id="live-status" style="color:var(--green);font-size:11px;margin-right:8px">&#x25CF; polling 5s</span>
+        <button class="export-btn" onclick="stopLiveSession()">Close</button>
+      </div>
+    </div>
+    <div id="live-summary" style="padding:10px 14px;color:var(--muted);font-size:12px;border-bottom:1px solid var(--border)"></div>
+    <table>
+      <thead><tr>
+        <th style="width:50px">#</th>
+        <th>Time <span id="live-tz-label" class="muted" style="font-weight:normal">(local)</span></th>
+        <th>Your Message</th>
+        <th class="num">Turns</th>
+        <th class="num">Tools</th>
+        <th class="num">Input</th>
+        <th class="num">Output</th>
+        <th class="num">Cache R</th>
+        <th class="num">Cache W</th>
+        <th class="num">Cost</th>
+      </tr></thead>
+      <tbody id="live-turns-body"></tbody>
     </table>
   </div>
   <div class="table-card">
@@ -519,6 +882,20 @@ function getRangeBounds(range) {
   const d = new Date();
   d.setDate(d.getDate() - days);
   return { start: iso(d), end: null };
+}
+
+// Number of calendar days the selected range spans (used as denominator
+// for "average per day" charts so inactive days still count).
+function rangeCalendarDays(range, startISO, endISO) {
+  if (range === 'all') return 0;  // unknown — caller falls back to active-days
+  const MS = 86400000;
+  const today = new Date();
+  const todayISO = today.toISOString().slice(0, 10);
+  const effectiveEndISO = endISO || todayISO;
+  if (!startISO) return 0;
+  const s = new Date(startISO + 'T00:00:00Z');
+  const e = new Date(effectiveEndISO + 'T00:00:00Z');
+  return Math.max(1, Math.round((e - s) / MS) + 1);
 }
 
 function readURLRange() {
@@ -740,11 +1117,12 @@ function applyFilter() {
     cost:           byModel.reduce((s, m) => s + calcCost(m.model, m.input, m.output, m.cache_read, m.cache_creation), 0),
   };
 
-  // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
+  // Hourly aggregation (filtered by model + range, bucketed by local hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
-  const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
+  const rangeDayCount = rangeCalendarDays(selectedRange, start, end);
+  const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ, rangeDayCount);
 
   // Update daily chart title
   document.getElementById('daily-chart-title').textContent = 'Daily Token Usage \u2014 ' + RANGE_LABELS[selectedRange];
@@ -753,15 +1131,19 @@ function applyFilter() {
   renderStats(totals);
   renderDailyChart(daily);
   renderHourlyChart(hourlyAgg);
-  renderModelChart(byModel);
+  renderEfficiencyChart(totals);
   renderProjectChart(byProject);
   lastFilteredSessions = sortSessions(filteredSessions);
   lastByProject = sortProjects(byProject);
   lastByProjectBranch = sortProjectBranch(byProjectBranch);
   renderSessionsTable(lastFilteredSessions.slice(0, 20));
-  renderModelCostTable(byModel);
   renderProjectCostTable(lastByProject.slice(0, 20));
   renderProjectBranchCostTable(lastByProjectBranch.slice(0, 20));
+}
+
+function projectLabel(proj) {
+  const m = (rawData && rawData.project_labels) || {};
+  return m[proj] || proj;
 }
 
 // ── Renderers ──────────────────────────────────────────────────────────────
@@ -786,18 +1168,25 @@ function renderStats(t) {
 }
 
 // Bucket rows into 24 hours (display-TZ), summing turns + output, and count
-// the unique days in the input so the caller can compute per-day averages.
-function aggregateHourly(rows, tzMode) {
+// the calendar days in the selected range so averages divide by window size,
+// not by active-days-only.
+//
+// NOTE: server pre-applies SQL_TZ_SHIFT, so r.hour is already in local time.
+// For 'local' display, use as-is. For 'utc', subtract the local offset.
+function aggregateHourly(rows, tzMode, rangeDayCount) {
   const byHour = {};
   for (let h = 0; h < 24; h++) byHour[h] = { turns: 0, output: 0 };
   const days = new Set();
   for (const r of rows) {
-    const displayHour = utcHourToDisplay(r.hour, tzMode);
+    const displayHour = tzMode === 'local'
+      ? r.hour
+      : ((r.hour - localOffsetHours()) % 24 + 24) % 24;
     byHour[displayHour].turns  += r.turns  || 0;
     byHour[displayHour].output += r.output || 0;
     if (r.day) days.add(r.day);
   }
-  const dayCount = days.size;
+  // Prefer the range's calendar-day count; fall back to active days for 'all'.
+  const dayCount = rangeDayCount && rangeDayCount > 0 ? rangeDayCount : days.size;
   const hours = [];
   for (let h = 0; h < 24; h++) {
     hours.push({
@@ -814,7 +1203,7 @@ function aggregateHourly(rows, tzMode) {
 function renderHourlyChart(agg) {
   const dayCountEl = document.getElementById('hourly-day-count');
   dayCountEl.textContent = agg.dayCount
-    ? agg.dayCount + ' day' + (agg.dayCount === 1 ? '' : 's') + ' averaged · ' + tzDisplayName(hourlyTZ)
+    ? 'avg / day over ' + agg.dayCount + ' day' + (agg.dayCount === 1 ? '' : 's') + ' · ' + tzDisplayName(hourlyTZ)
     : 'No data · ' + tzDisplayName(hourlyTZ);
 
   const ctx = document.getElementById('chart-hourly').getContext('2d');
@@ -909,24 +1298,159 @@ function renderDailyChart(daily) {
   });
 }
 
-function renderModelChart(byModel) {
-  const ctx = document.getElementById('chart-model').getContext('2d');
+// Efficiency model (based on Anthropic prompt-caching pricing, Apr 2026):
+//   cache_write = 1.25x base input price
+//   cache_read  = 0.10x base input price
+//   output      = ~5x input price (varies by model)
+// Composite efficiency score weights 4 sub-metrics:
+//   1. Cache Hit Rate     — reused / (reused + new_input)
+//   2. Reuse Ratio        — cache_read / cache_creation (writes paying off)
+//   3. Output Discipline  — penalize runaway output vs input
+//   4. Cost Efficiency    — actual_cost / hypothetical_no_cache_cost
+function computeEfficiency(t) {
+  const reused        = t.cache_read || 0;
+  const cacheWrite    = t.cache_creation || 0;
+  const freshInput    = t.input || 0;
+  const output        = t.output || 0;
+  const newInput      = freshInput + cacheWrite;
+  const totalInput    = reused + newInput;
+
+  // 1. Cache hit rate (0–100)
+  const cacheHitPct = totalInput > 0 ? (reused / totalInput) * 100 : 0;
+
+  // 2. Reuse ratio: how many times each cached write gets read back.
+  //   2.0+ = excellent, 1.0 = breakeven (cache cost recouped), <1 = wasted writes
+  const reuseRatio = cacheWrite > 0 ? reused / cacheWrite : (reused > 0 ? 10 : 0);
+
+  // 3. Output discipline: output should be small fraction of input you fed.
+  //   Healthy range 0.05–0.3. Above 0.5 = chatty.
+  const outputRatio = totalInput > 0 ? output / totalInput : 0;
+
+  // 4. Cost vs hypothetical no-cache. Saved = cache_read * 0.9 of base input price
+  //   (since cache_read = 0.1x). cache_write = 0.25x premium over base.
+  //   Effective rate vs no-cache baseline:
+  const noCacheCost = (reused + newInput) * 1.0;                  // all at 1.0x
+  const actualCost  = reused * 0.10 + cacheWrite * 1.25 + freshInput * 1.0;
+  const costEffPct  = noCacheCost > 0 ? (1 - actualCost / noCacheCost) * 100 : 0;
+
+  // Composite score 0–100 (weighted)
+  const cacheScore  = Math.min(100, cacheHitPct);                       // weight 0.40
+  const reuseScore  = Math.min(100, reuseRatio * 25);                   // weight 0.25 (4x reuse=100)
+  const outputScore = Math.max(0, 100 - Math.min(100, outputRatio*200));// weight 0.15
+  const costScore   = Math.max(0, Math.min(100, costEffPct));           // weight 0.20
+  const composite = cacheScore*0.40 + reuseScore*0.25 + outputScore*0.15 + costScore*0.20;
+
+  let grade = 'F', color = '#ef4444';
+  if (composite >= 90)      { grade = 'A+'; color = '#22c55e'; }
+  else if (composite >= 80) { grade = 'A';  color = '#4ade80'; }
+  else if (composite >= 70) { grade = 'B';  color = '#84cc16'; }
+  else if (composite >= 60) { grade = 'C';  color = '#facc15'; }
+  else if (composite >= 50) { grade = 'D';  color = '#fb923c'; }
+
+  // $ saved estimate using blended input price ($5/M ballpark across opus/sonnet/haiku)
+  const BLENDED_INPUT_PRICE_PER_M = 5;
+  const savedUSD = (noCacheCost - actualCost) * BLENDED_INPUT_PRICE_PER_M / 1_000_000;
+
+  return {
+    reused, cacheWrite, freshInput, newInput, output, totalInput,
+    cacheHitPct, reuseRatio, outputRatio, costEffPct,
+    cacheScore, reuseScore, outputScore, costScore,
+    composite, grade, color, savedUSD,
+  };
+}
+
+function toggleEffHelp() {
+  const el = document.getElementById('eff-help');
+  if (!el) return;
+  el.style.display = el.style.display === 'none' ? 'block' : 'none';
+}
+function renderEfficiencyChart(totals) {
+  const ctx = document.getElementById('chart-efficiency').getContext('2d');
   if (charts.model) charts.model.destroy();
-  if (!byModel.length) { charts.model = null; return; }
+  const e = computeEfficiency(totals);
+  const totalEff = e.reused + e.newInput + e.output;
+  if (totalEff === 0) {
+    charts.model = null;
+    document.getElementById('efficiency-grade').textContent='';
+    renderEfficiencyBreakdown(e);
+    return;
+  }
+  document.getElementById('efficiency-grade').innerHTML =
+    `<span style="color:${e.color}">Grade ${e.grade} &middot; ${e.composite.toFixed(0)}/100</span>`;
   charts.model = new Chart(ctx, {
     type: 'doughnut',
     data: {
-      labels: byModel.map(m => m.model),
-      datasets: [{ data: byModel.map(m => m.input + m.output), backgroundColor: MODEL_COLORS, borderWidth: 2, borderColor: '#1a1d27' }]
+      labels: ['Cache Reused (0.10x price)', 'Cache Write (1.25x price)', 'Fresh Input (1.0x)', 'Output (generated)'],
+      datasets: [{
+        data: [e.reused, e.cacheWrite, e.freshInput, e.output],
+        backgroundColor: ['#22c55e', '#facc15', '#fb923c', '#4f8ef7'],
+        borderWidth: 2, borderColor: '#1a1d27'
+      }]
     },
     options: {
       responsive: true, maintainAspectRatio: false,
       plugins: {
         legend: { position: 'bottom', labels: { color: '#8892a4', boxWidth: 12, font: { size: 11 } } },
-        tooltip: { callbacks: { label: ctx => ` ${ctx.label}: ${fmt(ctx.raw)} tokens` } }
+        tooltip: { callbacks: { label: ctx => ` ${ctx.label}: ${fmt(ctx.raw)} (${((ctx.raw/totalEff)*100).toFixed(1)}%)` } }
       }
     }
   });
+  renderEfficiencyBreakdown(e);
+}
+
+function renderEfficiencyBreakdown(e) {
+  const tips = [];
+  if (e.cacheHitPct < 70) tips.push(`Cache hit rate ${e.cacheHitPct.toFixed(0)}% — keep sessions running. Each new \`claude\` session restarts cache. Cache TTL ~5 min, so flurries of activity within 5 min reuse best.`);
+  if (e.reuseRatio < 1.5 && e.cacheWrite > 0) tips.push(`Reuse ratio ${e.reuseRatio.toFixed(2)}x — cache writes barely paying off. Either you exit sessions too fast, or context churns (lots of edits invalidating cache).`);
+  if (e.outputRatio > 0.3) tips.push(`Output/input ratio ${(e.outputRatio*100).toFixed(0)}% — model generating heavy. Add "respond in under 200 words" or "report concisely" to prompts.`);
+  if (e.freshInput > 500000) tips.push(`${fmt(e.freshInput)} fresh-input tokens — files re-read often. Read specific line ranges instead of whole files.`);
+  if (e.composite >= 80) tips.push(`Strong efficiency overall. Score ${e.composite.toFixed(0)}/100.`);
+  if (!tips.length) tips.push('Solid efficiency — keep current habits.');
+
+  const subScores = [
+    { label: 'Cache Hit',       v: e.cacheHitPct.toFixed(1)+'%',           score: e.cacheScore,  weight: '40%', hint: 'reused / total input' },
+    { label: 'Reuse Ratio',     v: e.reuseRatio.toFixed(2)+'x',            score: e.reuseScore,  weight: '25%', hint: 'reads per write (4x = 100)' },
+    { label: 'Output Discipline', v: (e.outputRatio*100).toFixed(0)+'%',   score: e.outputScore, weight: '15%', hint: 'output / total input — lower better' },
+    { label: 'Cost Efficiency', v: e.costEffPct.toFixed(0)+'%',            score: e.costScore,   weight: '20%', hint: '$ saved vs no-cache baseline' },
+  ];
+
+  const headerCards = [
+    { label: 'Composite Grade',  value: e.grade,                          sub: `${e.composite.toFixed(0)}/100 weighted`,    color: e.color },
+    { label: 'Est. $ Saved',     value: '$' + e.savedUSD.toFixed(2),      sub: 'vs running without cache',                  color: '#4ade80' },
+    { label: 'Reused Tokens',    value: fmt(e.reused),                    sub: 'pulled from prompt cache' },
+    { label: 'New Input Tokens', value: fmt(e.newInput),                  sub: 'fresh + cache writes (full price)' },
+  ];
+
+  const headerHTML = headerCards.map(c => `
+    <div style="background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:12px">
+      <div style="color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:0.05em">${c.label}</div>
+      <div style="font-size:22px;font-weight:600;margin-top:4px;color:${c.color||'var(--text)'}">${c.value}</div>
+      <div style="color:var(--muted);font-size:11px;margin-top:2px">${c.sub}</div>
+    </div>`).join('');
+
+  const subScoreHTML = subScores.map(s => {
+    const bar = Math.max(0, Math.min(100, s.score));
+    const barColor = bar>=70?'#4ade80':bar>=50?'#facc15':'#ef4444';
+    return `
+    <div style="background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:12px">
+      <div style="display:flex;justify-content:space-between;align-items:baseline">
+        <span style="color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:0.05em">${s.label}</span>
+        <span class="muted" style="font-size:10px">weight ${s.weight}</span>
+      </div>
+      <div style="font-size:18px;font-weight:600;margin:4px 0;color:var(--text)">${s.v}</div>
+      <div style="height:6px;background:var(--border);border-radius:3px;overflow:hidden;margin:6px 0">
+        <div style="width:${bar}%;height:100%;background:${barColor}"></div>
+      </div>
+      <div style="color:var(--muted);font-size:11px">${s.hint}</div>
+    </div>`;
+  }).join('');
+
+  document.getElementById('efficiency-body').innerHTML =
+    headerHTML + subScoreHTML +
+    `<div style="grid-column:1/-1;background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:12px">
+      <div style="color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:6px">Recommendations</div>
+      <ul style="margin:0;padding-left:20px;color:var(--text);font-size:12px;line-height:1.6">${tips.map(t=>`<li>${esc(t)}</li>`).join('')}</ul>
+    </div>`;
 }
 
 function renderProjectChart(byProject) {
@@ -937,7 +1461,7 @@ function renderProjectChart(byProject) {
   charts.project = new Chart(ctx, {
     type: 'bar',
     data: {
-      labels: top.map(p => p.project.length > 22 ? '\u2026' + p.project.slice(-20) : p.project),
+      labels: top.map(p => { const lbl = projectLabel(p.project); return lbl.length > 30 ? lbl.slice(0,28)+'\u2026' : lbl; }),
       datasets: [
         { label: 'Input',  data: top.map(p => p.input),  backgroundColor: TOKEN_COLORS.input },
         { label: 'Output', data: top.map(p => p.output), backgroundColor: TOKEN_COLORS.output },
@@ -960,8 +1484,11 @@ function renderSessionsTable(sessions) {
     const costCell = isBillable(s.model)
       ? `<td class="cost">${fmtCost(cost)}</td>`
       : `<td class="cost-na">n/a</td>`;
-    return `<tr>
+    const fullId = s.session_id_full || s.session_id;
+    const title = s.title || '<span class="muted">(no prompt)</span>';
+    return `<tr style="cursor:pointer" onclick="startLiveSession('${esc(fullId)}')">
       <td class="muted" style="font-family:monospace">${esc(s.session_id)}&hellip;</td>
+      <td>${typeof s.title === 'string' && s.title ? esc(s.title) : '<span class="muted">(no prompt)</span>'}</td>
       <td>${esc(s.project)}</td>
       <td class="muted">${esc(s.last)}</td>
       <td class="muted">${esc(s.duration_min)}m</td>
@@ -972,6 +1499,70 @@ function renderSessionsTable(sessions) {
       ${costCell}
     </tr>`;
   }).join('');
+}
+
+// ── Live session view ────────────────────────────────────────────────────────
+let liveSessionId = null;
+let liveTimer = null;
+
+function startLiveSession(sid) {
+  liveSessionId = sid;
+  document.getElementById('live-session-card').style.display = '';
+  document.getElementById('live-session-card').scrollIntoView({behavior:'smooth', block:'start'});
+  fetchLiveSession();
+  if (liveTimer) clearInterval(liveTimer);
+  liveTimer = setInterval(fetchLiveSession, 5000);
+}
+
+function stopLiveSession() {
+  liveSessionId = null;
+  if (liveTimer) { clearInterval(liveTimer); liveTimer = null; }
+  document.getElementById('live-session-card').style.display = 'none';
+}
+
+async function fetchLiveSession() {
+  if (!liveSessionId) return;
+  try {
+    const res = await fetch('/api/session/' + encodeURIComponent(liveSessionId));
+    const d = await res.json();
+    if (d.error) {
+      document.getElementById('live-summary').textContent = d.error;
+      return;
+    }
+    const cost = calcCost(d.model, d.totals.input, d.totals.output, d.totals.cache_read, d.totals.cache_creation);
+    document.getElementById('live-title').textContent = d.title || '(no prompt) — ' + d.session_id.slice(0,8);
+    document.getElementById('live-summary').innerHTML =
+      `<b>${esc(d.project)}</b> &middot; ${esc(d.model)} &middot; ${d.turn_count} turns &middot; ` +
+      `Input ${fmt(d.totals.input)} &middot; Output ${fmt(d.totals.output)} &middot; ` +
+      `Cache R/W ${fmt(d.totals.cache_read)}/${fmt(d.totals.cache_creation)} &middot; ` +
+      `<span style="color:var(--green)">Est. ${fmtCost(cost)}</span> &middot; ` +
+      `Last: ${esc((d.last||'').replace('T',' ').slice(0,19))}`;
+    const msgs = d.messages || [];
+    if (rawData && rawData.tz_name) {
+      const tzEl = document.getElementById('live-tz-label');
+      if (tzEl) tzEl.textContent = '(' + rawData.tz_name + ')';
+    }
+    const rows = msgs.slice().reverse().map((m, idx) => {
+      const realIdx = msgs.length - idx;
+      const c = calcCost(m.model || d.model, m.input, m.output, m.cache_read, m.cache_creation);
+      const tools = (m.tools||[]).join(', ');
+      return `<tr>
+        <td class="muted num">#${realIdx}</td>
+        <td class="muted" style="font-family:monospace;font-size:11px">${esc((m.timestamp||'').replace('T',' ').slice(0,19))}</td>
+        <td style="max-width:400px;white-space:normal;font-size:12px">${esc(m.prompt||'(empty)')}</td>
+        <td class="num">${m.turn_count}</td>
+        <td class="muted num" style="font-size:11px">${esc(tools)}</td>
+        <td class="num">${fmt(m.input)}</td>
+        <td class="num">${fmt(m.output)}</td>
+        <td class="num">${fmt(m.cache_read)}</td>
+        <td class="num">${fmt(m.cache_creation)}</td>
+        <td class="num cost">${fmtCost(c)}</td>
+      </tr>`;
+    }).join('');
+    document.getElementById('live-turns-body').innerHTML = rows || '<tr><td colspan="10" class="muted" style="padding:20px;text-align:center">No messages parsed</td></tr>';
+  } catch (e) {
+    document.getElementById('live-summary').textContent = 'Error: ' + e.message;
+  }
 }
 
 function setModelSort(col) {
@@ -1056,7 +1647,7 @@ function sortProjects(byProject) {
 function renderProjectCostTable(byProject) {
   document.getElementById('project-cost-body').innerHTML = sortProjects(byProject).map(p => {
     return `<tr>
-      <td>${esc(p.project)}</td>
+      <td>${esc(projectLabel(p.project))} <span class="muted" style="font-size:10px">${esc(p.project)}</span></td>
       <td class="num">${p.sessions}</td>
       <td class="num">${fmt(p.turns)}</td>
       <td class="num">${fmt(p.input)}</td>
@@ -1231,6 +1822,149 @@ function scheduleAutoRefresh() {
 
 loadData();
 scheduleAutoRefresh();
+
+// ── Live limits banner ─────────────────────────────────────────────────────
+function fmtTokens(n) {
+  if (n == null) return '—';
+  if (n >= 1e6) return (n / 1e6).toFixed(2) + 'M';
+  if (n >= 1e3) return (n / 1e3).toFixed(1) + 'k';
+  return String(n);
+}
+function fmtCountdown(resetIso) {
+  if (!resetIso) return '—';
+  const ms = new Date(resetIso).getTime() - Date.now();
+  if (ms <= 0) return 'resets now';
+  const m = Math.floor(ms / 60000);
+  const h = Math.floor(m / 60);
+  const mm = m % 60;
+  if (h > 0) return `resets in ${h}h ${mm}m`;
+  if (m > 0) return `resets in ${m}m`;
+  return `resets in <1m`;
+}
+function applyBar(cardId, used, cap, pct, footRight) {
+  const el = document.getElementById(cardId);
+  if (!el) return;
+  const fill = el.querySelector('.lc-fill');
+  const pctEl = el.querySelector('.lc-pct');
+  const usedEl = el.querySelector('.lc-used');
+  const resetEl = el.querySelector('.lc-reset');
+  if (!cap) {
+    el.classList.add('lc-disabled');
+    fill.style.width = '0%';
+    pctEl.textContent = 'n/a';
+    usedEl.innerHTML = '<strong>' + fmtTokens(used) + '</strong> used';
+    resetEl.textContent = 'not included in plan';
+    return;
+  }
+  el.classList.remove('lc-disabled');
+  const p = pct == null ? 0 : pct;
+  fill.style.width = Math.min(100, p) + '%';
+  fill.classList.remove('warn', 'danger');
+  if (p >= 90) fill.classList.add('danger');
+  else if (p >= 70) fill.classList.add('warn');
+  pctEl.textContent = p.toFixed(1) + '%';
+  usedEl.innerHTML = '<strong>' + fmtTokens(used) + '</strong> / ' + fmtTokens(cap);
+  resetEl.textContent = footRight;
+}
+const LIMITS_MODEL_COLORS = { opus: '#d97757', sonnet: '#4f8ef7', haiku: '#4ade80', other: '#8892a4' };
+function renderWeeklyBar(wk) {
+  const el = document.getElementById('lc-weekly');
+  if (!el) return;
+  const bar = el.querySelector('.lc-bar');
+  const pctEl = el.querySelector('.lc-pct');
+  const usedEl = el.querySelector('.lc-used');
+  const cap = wk.cap || 0;
+  const used = wk.used || 0;
+  const totalPct = wk.percent == null ? 0 : wk.percent;
+  pctEl.textContent = totalPct.toFixed(1) + '%';
+  usedEl.innerHTML = '<strong>' + fmtTokens(used) + '</strong> / ' + fmtTokens(cap);
+  const order = ['opus', 'sonnet', 'haiku', 'other'];
+  const byTokens = wk.by_model || {};
+  const segs = order
+    .filter(k => (byTokens[k] || 0) > 0)
+    .map(k => {
+      const pct = cap > 0 ? (byTokens[k] / cap) * 100 : 0;
+      return `<div class="lc-seg" style="width:${pct}%;background:${LIMITS_MODEL_COLORS[k]}" title="${k}: ${fmtTokens(byTokens[k])} (${pct.toFixed(1)}%)"></div>`;
+    });
+  bar.innerHTML = segs.join('') || '<div class="lc-fill" style="width:0%"></div>';
+}
+function renderWeeklyModels(wk) {
+  const host = document.getElementById('lc-weekly-models');
+  if (!host) return;
+  const byPct = wk.by_model_pct || {};
+  const byTokens = wk.by_model || {};
+  const order = ['opus', 'sonnet', 'haiku', 'other'];
+  const parts = order
+    .filter(k => (byTokens[k] || 0) > 0)
+    .map(k => `<span class="lc-model"><span class="lc-swatch" style="background:${LIMITS_MODEL_COLORS[k]}"></span>${k} ${byPct[k]||0}% · ${fmtTokens(byTokens[k]||0)}</span>`);
+  host.innerHTML = parts.join('');
+}
+function renderHealth(h) {
+  const card = document.getElementById('lc-health');
+  const msg = document.getElementById('health-msg');
+  const sid = document.getElementById('health-session-id');
+  const stats = document.getElementById('health-stats');
+  if (!card || !msg) return;
+  card.classList.remove('health-ok', 'health-info', 'health-warn');
+  if (!h.active) {
+    card.classList.add('health-ok');
+    msg.textContent = 'No active session in the last 30 minutes.';
+    sid.textContent = '—';
+    stats.innerHTML = '';
+    return;
+  }
+  card.classList.add('health-' + (h.level || 'ok'));
+  msg.textContent = h.message || '';
+  sid.textContent = h.session_id || '';
+  const parts = [];
+  if (h.context_size != null) parts.push(`context ${fmtTokens(h.context_size)}`);
+  if (h.cache_hit_rate != null) parts.push(`cache hit ${(h.cache_hit_rate*100).toFixed(0)}%`);
+  if (h.avg_billable_per_turn != null) parts.push(`avg ${fmtTokens(h.avg_billable_per_turn)}/turn`);
+  if (h.session_age_hours != null) parts.push(`age ${h.session_age_hours}h`);
+  stats.innerHTML = parts.map(p => `<span>${p}</span>`).join(' · ');
+}
+let limitsTimer = null;
+let _userPlanOverride = localStorage.getItem('claudeUsagePlanOverride') || '';
+function onPlanOverride() {
+  const v = document.getElementById('plan-select').value;
+  _userPlanOverride = v;
+  if (v) localStorage.setItem('claudeUsagePlanOverride', v);
+  else localStorage.removeItem('claudeUsagePlanOverride');
+  loadLimits();
+}
+async function loadLimits() {
+  try {
+    const url = _userPlanOverride
+      ? '/api/limits?plan=' + encodeURIComponent(_userPlanOverride)
+      : '/api/limits';
+    const resp = await fetch(url);
+    const data = await resp.json();
+    if (data.error) return;
+    const sel = document.getElementById('plan-select');
+    if (sel && sel.value !== _userPlanOverride) sel.value = _userPlanOverride;
+    const planSrc = document.getElementById('plan-source');
+    if (planSrc) {
+      const label = (data.plan && data.plan.label) || '—';
+      const src = (data.plan && data.plan.source) || 'default';
+      planSrc.textContent = `${label} (${src})`;
+    }
+    const wk = data.weekly_all || {};
+    renderWeeklyBar(wk);
+    renderWeeklyModels(wk);
+    renderHealth(data.session_health || {});
+  } catch (e) { /* network blip */ }
+}
+function scheduleLimits() {
+  if (limitsTimer) clearInterval(limitsTimer);
+  limitsTimer = setInterval(loadLimits, 10000);
+}
+// Restore override into select before first fetch.
+(function () {
+  const sel = document.getElementById('plan-select');
+  if (sel && _userPlanOverride) sel.value = _userPlanOverride;
+})();
+loadLimits();
+scheduleLimits();
 </script>
 </body>
 </html>
@@ -1249,7 +1983,48 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self.wfile.write(HTML_TEMPLATE.encode("utf-8"))
 
         elif self.path == "/api/data":
+            # Incremental scan so data stays live without manual rescan.
+            try:
+                import scanner
+                scanner.scan(db_path=DB_PATH, projects_dirs=scanner.DEFAULT_PROJECTS_DIRS, verbose=False)
+            except Exception:
+                pass
             data = get_dashboard_data()
+            body = json.dumps(data).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        elif self.path.startswith("/api/limits"):
+            override = None
+            if "?" in self.path:
+                from urllib.parse import parse_qs
+                qs = parse_qs(self.path.split("?", 1)[1])
+                override = (qs.get("plan") or [None])[0]
+            try:
+                import limits
+                if override and override in limits.PLAN_BUDGETS:
+                    os.environ["CLAUDE_USAGE_PLAN"] = override
+                data = limits.get_limits(db_path=DB_PATH)
+            except Exception as e:
+                data = {"error": str(e)}
+            body = json.dumps(data).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        elif self.path.startswith("/api/session/"):
+            sid = self.path[len("/api/session/"):].split("?")[0].split("/")[0]
+            try:
+                import scanner
+                scanner.scan(db_path=DB_PATH, projects_dirs=scanner.DEFAULT_PROJECTS_DIRS, verbose=False)
+            except Exception:
+                pass
+            data = get_session_live(sid)
             body = json.dumps(data).encode("utf-8")
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
@@ -1290,7 +2065,7 @@ class DashboardHandler(BaseHTTPRequestHandler):
 def serve(host=None, port=None):
     host = host or os.environ.get("HOST", "localhost")
     port = port or int(os.environ.get("PORT", "8080"))
-    server = HTTPServer((host, port), DashboardHandler)
+    server = ThreadingHTTPServer((host, port), DashboardHandler)
     print(f"Dashboard running at http://{host}:{port}")
     print("Press Ctrl+C to stop.")
     try:

--- a/limits.py
+++ b/limits.py
@@ -1,0 +1,515 @@
+"""
+limits.py - Compute live remaining usage for Claude Code plan windows.
+
+Anthropic enforces two windows on Claude subscriptions:
+  - 5-hour rolling session ("session limit")
+  - 7-day rolling weekly window (separate caps per model family)
+
+This module reads the local `turns` table (populated by scanner.py from
+JSONL transcripts) and computes used/remaining/reset for both windows.
+
+Plan caps are approximate and community-derived. Anthropic does not
+publish exact token budgets, and they drift over time. The dashboard
+labels values as estimates.
+
+Claude.ai web usage shares the same plan quota but is NOT written to
+local JSONL — these numbers may understate consumption for heavy web
+users.
+"""
+
+import json
+import os
+import subprocess
+import sqlite3
+import time
+import urllib.request
+import urllib.error
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+DB_PATH = Path.home() / ".claude" / "usage.db"
+PLAN_CACHE_PATH = Path.home() / ".claude" / "usage-plan-cache.json"
+PLAN_CACHE_TTL_SECONDS = 24 * 3600
+
+# Approximate per-plan budgets. Source: Anthropic public docs + community
+# observation. Token figures are rough — used for progress bars only.
+# Keys:
+#   session_5h_tokens: total billable tokens (input + output + cache_creation)
+#                      typically consumed within a 5h window at the cap
+#   weekly_sonnet_tokens / weekly_opus_tokens: rolling 7d caps per model
+PLAN_BUDGETS = {
+    "pro": {
+        "label": "Pro",
+        "session_5h_tokens": 613_000,
+        "weekly_all_tokens": 23_000_000,
+    },
+    "max_5x": {
+        "label": "Max 5×",
+        "session_5h_tokens": 3_065_000,
+        "weekly_all_tokens": 115_000_000,
+    },
+    "max_20x": {
+        "label": "Max 20×",
+        "session_5h_tokens": 12_260_000,
+        "weekly_all_tokens": 460_000_000,
+    },
+}
+
+# Anthropic's session/weekly limits appear to use cost-weighted tokens,
+# where cache reads count at roughly 1/10 of input. This matches API
+# pricing (cache_read = 10% of input cost) and reproduces the
+# percentages shown by `claude /usage` to within a few points.
+CACHE_READ_WEIGHT = 0.1
+
+DEFAULT_PLAN = "pro"
+
+
+# ── Plan detection ─────────────────────────────────────────────────────────
+
+def _read_keychain_oauth():
+    """Read Claude Code OAuth credentials from macOS keychain."""
+    try:
+        out = subprocess.run(
+            ["security", "find-generic-password", "-s",
+             "Claude Code-credentials", "-w"],
+            capture_output=True, text=True, timeout=3,
+        )
+        if out.returncode != 0:
+            return None
+        return json.loads(out.stdout.strip())
+    except (subprocess.SubprocessError, json.JSONDecodeError, OSError):
+        return None
+
+
+def _fetch_plan_from_api(access_token, timeout=4):
+    """Call Anthropic profile endpoint, return raw plan string or None.
+
+    Endpoint is undocumented and may change. We try a couple of known
+    paths and return the first that gives an organization_type-like field.
+    """
+    candidates = [
+        "https://api.anthropic.com/api/oauth/profile",
+        "https://api.anthropic.com/api/account",
+    ]
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "anthropic-beta": "oauth-2025-04-20",
+        "User-Agent": "claude-usage-dashboard/1.0",
+    }
+    for url in candidates:
+        try:
+            req = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+            for path in (
+                ("organization", "organization_type"),
+                ("subscription", "tier"),
+                ("plan",),
+                ("account", "plan"),
+            ):
+                cur = data
+                ok = True
+                for k in path:
+                    if isinstance(cur, dict) and k in cur:
+                        cur = cur[k]
+                    else:
+                        ok = False
+                        break
+                if ok and isinstance(cur, str):
+                    return cur
+        except (urllib.error.URLError, urllib.error.HTTPError,
+                json.JSONDecodeError, TimeoutError, OSError):
+            continue
+    return None
+
+
+def _normalize_plan(raw):
+    if not raw:
+        return None
+    r = raw.lower().replace("-", "_").replace(" ", "_")
+    if "20" in r and "max" in r:
+        return "max_20x"
+    if "5" in r and "max" in r:
+        return "max_5x"
+    if "max" in r:
+        return "max_5x"
+    if "pro" in r or "claude_pro" in r:
+        return "pro"
+    return None
+
+
+def _load_cached_plan():
+    try:
+        with open(PLAN_CACHE_PATH) as f:
+            data = json.load(f)
+        if time.time() - data.get("fetched_at", 0) < PLAN_CACHE_TTL_SECONDS:
+            return data.get("plan")
+    except (OSError, json.JSONDecodeError):
+        pass
+    return None
+
+
+def _save_cached_plan(plan):
+    try:
+        PLAN_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(PLAN_CACHE_PATH, "w") as f:
+            json.dump({"plan": plan, "fetched_at": time.time()}, f)
+    except OSError:
+        pass
+
+
+def detect_plan():
+    """Resolve the active Claude plan.
+
+    Priority:
+      1. CLAUDE_USAGE_PLAN env var (manual override)
+      2. 24h-cached lookup result
+      3. Live keychain + API lookup
+      4. DEFAULT_PLAN
+
+    Returns dict with keys: plan, label, source, budgets, detected_raw.
+    """
+    override = os.environ.get("CLAUDE_USAGE_PLAN", "").strip().lower()
+    if override in PLAN_BUDGETS:
+        return _plan_response(override, "env_override", raw=override)
+
+    cached = _load_cached_plan()
+    if cached in PLAN_BUDGETS:
+        return _plan_response(cached, "cache", raw=cached)
+
+    creds = _read_keychain_oauth()
+    raw = None
+    if creds:
+        token = (creds.get("claudeAiOauth") or {}).get("accessToken")
+        if token:
+            raw = _fetch_plan_from_api(token)
+
+    normalized = _normalize_plan(raw)
+    if normalized in PLAN_BUDGETS:
+        _save_cached_plan(normalized)
+        return _plan_response(normalized, "api", raw=raw)
+
+    return _plan_response(DEFAULT_PLAN, "default", raw=raw)
+
+
+def _plan_response(plan, source, raw=None):
+    b = PLAN_BUDGETS[plan]
+    return {
+        "plan": plan,
+        "label": b["label"],
+        "source": source,
+        "detected_raw": raw,
+        "budgets": b,
+    }
+
+
+# ── Window calculations ────────────────────────────────────────────────────
+
+def _connect(db_path=DB_PATH):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _model_family(model):
+    if not model:
+        return "other"
+    m = model.lower()
+    if "opus" in m:
+        return "opus"
+    if "sonnet" in m:
+        return "sonnet"
+    if "haiku" in m:
+        return "haiku"
+    return "other"
+
+
+def _billable(row):
+    # Weighted-token formula: matches Anthropic's `claude /usage`
+    # percentages. Cache reads are heavily discounted (~0.1×) since
+    # they're served from cache and priced accordingly.
+    return int(
+        (row["input_tokens"] or 0)
+        + (row["output_tokens"] or 0)
+        + (row["cache_creation_tokens"] or 0)
+        + (row["cache_read_tokens"] or 0) * CACHE_READ_WEIGHT
+    )
+
+
+def compute_session_5h(conn, now=None):
+    """Compute the active 5h rolling session window.
+
+    Anthropic's rule: the session window opens with your first message
+    and closes 5h after that anchor. Once closed, the next message starts
+    a new window.
+
+    Approximation: find the most recent turn. Walk backwards collecting
+    contiguous turns within 5h of the prior. The anchor is the earliest
+    turn in that contiguous block.
+    """
+    now = now or datetime.now(timezone.utc)
+    five_h = timedelta(hours=5)
+
+    rows = conn.execute(
+        "SELECT timestamp, model, input_tokens, output_tokens, "
+        "       cache_creation_tokens, cache_read_tokens "
+        "FROM turns "
+        "WHERE timestamp >= ? "
+        "ORDER BY timestamp ASC",
+        ((now - timedelta(hours=10)).isoformat(),),
+    ).fetchall()
+
+    if not rows:
+        return {
+            "active": False,
+            "used_tokens": 0,
+            "turns": 0,
+            "anchor_at": None,
+            "reset_at": None,
+            "by_model": {},
+        }
+
+    anchor_ts = None
+    used = 0
+    by_model = {}
+    turns = 0
+    for r in rows:
+        try:
+            ts = datetime.fromisoformat(r["timestamp"].replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            continue
+        if anchor_ts is None or ts - anchor_ts > five_h:
+            anchor_ts = ts
+            used = 0
+            by_model = {}
+            turns = 0
+        tokens = _billable(r)
+        used += tokens
+        turns += 1
+        fam = _model_family(r["model"])
+        by_model[fam] = by_model.get(fam, 0) + tokens
+
+    if anchor_ts is None:
+        return {
+            "active": False, "used_tokens": 0, "turns": 0,
+            "anchor_at": None, "reset_at": None, "by_model": {},
+        }
+
+    reset_at = anchor_ts + five_h
+    active = reset_at > now
+
+    return {
+        "active": active,
+        "used_tokens": used,
+        "turns": turns,
+        "anchor_at": anchor_ts.isoformat(),
+        "reset_at": reset_at.isoformat(),
+        "by_model": by_model,
+    }
+
+
+def compute_weekly(conn, now=None):
+    """Compute rolling 7-day usage. Anthropic uses a single 'All models'
+    bucket for the weekly cap, plus a separate Claude Design bucket which
+    is not represented in local JSONL (web-only feature)."""
+    now = now or datetime.now(timezone.utc)
+    week_ago = now - timedelta(days=7)
+
+    rows = conn.execute(
+        "SELECT model, input_tokens, output_tokens, cache_creation_tokens, "
+        "       cache_read_tokens "
+        "FROM turns WHERE timestamp >= ?",
+        (week_ago.isoformat(),),
+    ).fetchall()
+
+    total = 0
+    by_model = {"opus": 0, "sonnet": 0, "haiku": 0, "other": 0}
+    for r in rows:
+        t = _billable(r)
+        total += t
+        by_model[_model_family(r["model"])] += t
+
+    return {
+        "window_start": week_ago.isoformat(),
+        "window_end": now.isoformat(),
+        "total": total,
+        "by_model": by_model,
+    }
+
+
+# ── Public API ─────────────────────────────────────────────────────────────
+
+def compute_efficiency_warning(conn, now=None):
+    """Inspect the most-recent active session and decide whether the user
+    should consider starting a fresh conversation.
+
+    Inefficiency signals (any one triggers a warning):
+      - Latest turn input_tokens > 150k → context near 200k limit
+      - Last 5 turns avg cache hit rate < 40% → cache keeps invalidating
+      - Last 5 turns avg billable tokens per turn > 60k → bloated context
+      - Session active > 3h → diminishing returns from a single thread
+    """
+    now = now or datetime.now(timezone.utc)
+    cutoff = (now - timedelta(minutes=30)).isoformat()
+
+    row = conn.execute(
+        "SELECT session_id, MAX(timestamp) AS last_ts "
+        "FROM turns WHERE timestamp >= ? "
+        "GROUP BY session_id ORDER BY last_ts DESC LIMIT 1",
+        (cutoff,),
+    ).fetchone()
+    if not row:
+        return {"active": False, "level": "ok", "message": None}
+
+    session_id = row["session_id"]
+    turns = conn.execute(
+        "SELECT timestamp, input_tokens, output_tokens, "
+        "       cache_creation_tokens, cache_read_tokens "
+        "FROM turns WHERE session_id = ? "
+        "ORDER BY timestamp DESC LIMIT 10",
+        (session_id,),
+    ).fetchall()
+    if not turns:
+        return {"active": False, "level": "ok", "message": None}
+
+    latest = turns[0]
+    latest_input = latest["input_tokens"] or 0
+    latest_cache_read = latest["cache_read_tokens"] or 0
+    context_size = latest_input + latest_cache_read
+
+    recent = turns[:5]
+    total_cache_read = sum((t["cache_read_tokens"] or 0) for t in recent)
+    total_input = sum((t["input_tokens"] or 0) for t in recent)
+    total_cache_creation = sum((t["cache_creation_tokens"] or 0) for t in recent)
+    total_billable = sum(_billable(t) for t in recent)
+    cache_hit_rate = (
+        total_cache_read / (total_cache_read + total_input + total_cache_creation)
+        if (total_cache_read + total_input + total_cache_creation) else 0
+    )
+    avg_billable = total_billable / len(recent)
+
+    first_ts = conn.execute(
+        "SELECT MIN(timestamp) AS t FROM turns WHERE session_id = ?",
+        (session_id,),
+    ).fetchone()["t"]
+    try:
+        anchor = datetime.fromisoformat(first_ts.replace("Z", "+00:00"))
+        session_age_hours = (now - anchor).total_seconds() / 3600
+    except (ValueError, AttributeError):
+        session_age_hours = 0
+
+    reasons = []
+    level = "ok"
+    if context_size > 150_000:
+        level = "warn"
+        reasons.append(
+            f"Context at ~{context_size//1000}k tokens (near 200k limit). "
+            "Start a new session to reclaim headroom."
+        )
+    if cache_hit_rate < 0.40 and total_cache_creation > 50_000:
+        level = "warn"
+        reasons.append(
+            f"Cache hit rate only {cache_hit_rate*100:.0f}% over last 5 "
+            "turns — context keeps invalidating. New session will "
+            "rebuild a clean cache."
+        )
+    if avg_billable > 60_000:
+        if level == "ok":
+            level = "info"
+        reasons.append(
+            f"Avg {int(avg_billable/1000)}k tokens/turn over last 5 "
+            "turns. Conversation is heavy — consider summarizing into "
+            "a new session."
+        )
+    if session_age_hours > 3:
+        if level == "ok":
+            level = "info"
+        reasons.append(
+            f"Session running {session_age_hours:.1f}h. Long threads "
+            "drift and re-process the same history repeatedly."
+        )
+
+    return {
+        "active": True,
+        "session_id": session_id[:8],
+        "level": level,
+        "context_size": context_size,
+        "cache_hit_rate": round(cache_hit_rate, 3),
+        "avg_billable_per_turn": int(avg_billable),
+        "session_age_hours": round(session_age_hours, 2),
+        "turns_inspected": len(recent),
+        "reasons": reasons,
+        "message": (
+            "Healthy session — keep going." if level == "ok"
+            else " ".join(reasons)
+        ),
+    }
+
+
+def get_limits(db_path=DB_PATH):
+    """Return the full limits payload for the dashboard."""
+    plan_info = detect_plan()
+    budgets = plan_info["budgets"]
+
+    try:
+        conn = _connect(db_path)
+        session = compute_session_5h(conn)
+        weekly = compute_weekly(conn)
+        warning = compute_efficiency_warning(conn)
+        conn.close()
+    except sqlite3.Error as e:
+        return {"error": str(e), "plan": plan_info}
+
+    def pct(used, cap):
+        if not cap:
+            return None
+        return min(100.0, round(100.0 * used / cap, 1))
+
+    session_cap = budgets["session_5h_tokens"]
+    weekly_cap = budgets["weekly_all_tokens"]
+
+    session_used = session["used_tokens"]
+    weekly_used = weekly["total"]
+
+    return {
+        "plan": plan_info,
+        "session_5h": {
+            "active": session["active"],
+            "used": session_used,
+            "cap": session_cap,
+            "remaining": max(0, session_cap - session_used),
+            "percent": pct(session_used, session_cap),
+            "turns": session["turns"],
+            "anchor_at": session["anchor_at"],
+            "reset_at": session["reset_at"],
+            "by_model": session["by_model"],
+        },
+        "weekly_all": {
+            "used": weekly_used,
+            "cap": weekly_cap,
+            "remaining": max(0, weekly_cap - weekly_used),
+            "percent": pct(weekly_used, weekly_cap),
+            "by_model": weekly["by_model"],
+            "by_model_pct": {
+                k: pct(v, weekly_cap) for k, v in weekly["by_model"].items()
+            },
+        },
+        "session_health": warning,
+        "weekly_claude_design": {
+            "trackable": False,
+            "note": "Claude Design usage is a Claude.ai web feature and "
+                    "is not written to local Claude Code JSONL. Check "
+                    "Settings → Usage in the Claude desktop app.",
+        },
+        "weekly_window_start": weekly["window_start"],
+        "note": (
+            "Estimates only. Anthropic does not publish exact token "
+            "budgets. Claude.ai web usage (incl. Claude Design) shares "
+            "the same plan quota but is not tracked locally — heavy "
+            "web use will under-report here."
+        ),
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(get_limits(), indent=2))


### PR DESCRIPTION
## Summary

Adds plan-budget visibility, session-health hints, a multi-metric efficiency grade, and a per-message live view of in-flight sessions. Also fixes a `ReferenceError` (`cutoff` → `start`/`end`) that was killing all charts, and replaces UTC-only timestamps with auto-detected local TZ.

All changes are additive — no breaking API changes, no new third-party deps, still standard-library only.

## What's new

### Live limits widget (`limits.py` + `/api/limits`)
- Weekly stacked bar (Opus / Sonnet / Haiku) with a per-model breakdown line: `opus X% · 5.5M  sonnet Y% · 550k  haiku Z%`.
- Plan auto-detect: macOS keychain → Anthropic OAuth profile endpoints → `CLAUDE_USAGE_PLAN` env → `pro` default. 24h cache at `~/.claude/usage-plan-cache.json`.
- Approximate budgets for `pro` / `max_5x` / `max_20x` (Anthropic doesn't publish exact caps — calibrated to within ~25% on real usage).
- Cache-read tokens weighted `0.1×` in billable totals to mirror Anthropic's cost-equivalent counting.
- `ThreadingHTTPServer` so `/api/limits` and `/api/data` don't block each other.

### Session Health card
Heuristic "start new session" warning when any of:
- Context > 150k tokens
- Cache hit rate < 40%
- Avg > 60k tokens/turn
- Session age > 3h

States: `ok` / `info` / `warn` with colored border.

### Token Efficiency grader (replaces "By Model" pie)
Weighted A/B/C/D grade:
- Cache Hit 40%
- Reuse Ratio 25%
- Cost Efficiency 20%
- Output Discipline 15%

`?` info button reveals the formula. Recalcs with `/api/data`, respects date-range filter.

### Per-message live session view (`/api/session/<id>`)
Click a session row → polls every 5s. Each user prompt shows token totals (input / output / cache_read / cache_creation), model, turn count, and tools used. Skill invocations and `<system-reminder>` blocks are filtered so the list shows real human turns only.

### Quality-of-life
- Session titles extracted from first JSONL user prompt (replaces opaque project IDs).
- Local timezone auto-detect via `datetime.now().astimezone().utcoffset()` — no more manual UTC offset.
- Hourly chart: average divides by calendar days in range, not active-days-only (was inflating averages); SQL pre-shifts hour to local so JS no longer double-shifts.
- Auto-rescan on every `/api/data` fetch (incremental scan is cheap).
- **Bug fix:** `cutoff` → `start`/`end` `ReferenceError` that was killing all charts in the previous filter refactor.

## Files touched

| File | Change |
|------|--------|
| `dashboard.py` | Adds limits banner, session health card, efficiency grader, live session route, TZ autodetect, hourly-average fix |
| `limits.py` | New — plan detection + budget computation |
| `README.md` | Fork notice + documents new features |

## Notes for review

- Plan budgets in `PLAN_BUDGETS` are approximations — happy to remove the table and surface "% of weekly" only if you prefer not to ship numbers Anthropic hasn't published.
- Session Health thresholds are tunable constants at the top of the JS — easy to move to a config block.
- All UI additions are gated behind their own components; existing dashboard layout unchanged.

Happy to split this into smaller PRs (limits / efficiency / live-view / bugfix) if that's easier to review. Let me know what you prefer.