### PR TITLE
Fix ReferenceError: cutoff is not defined in applyFilter

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
## What

`applyFilter` was refactored to destructure `{ start, end }` from `getRangeBounds`,
but the hourly chart's filter still references the removed `cutoff` variable
([dashboard.py:745](dashboard.py#L745)). This throws `ReferenceError: cutoff is
not defined` on every render, breaking the entire dashboard — no stats, no charts,
no tables.

## Repro

1. `python3 cli.py dashboard`
2. Open `http://localhost:8080`
3. Console: `ReferenceError: cutoff is not defined at applyFilter`

## Fix

Replace `cutoff` with the same `start`/`end` bounds used by the daily filter
at line 660, so the hourly chart respects the selected range too.

## Test plan

- [x] Repro confirmed on `main` (`grep cutoff dashboard.py` → 1 hit on line 745)
- [x] After fix: dashboard loads, all 4 charts render, sessions table populates
- [x] Range buttons (7d/30d/90d/all) still filter hourly chart correctly
