### PR TITLE
Fix 404 on bookmarked URLs with query strings

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -8,6 +8,7 @@ import sqlite3
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
 from datetime import datetime
+from urllib.parse import urlparse
 
 DB_PATH = Path.home() / ".claude" / "usage.db"
 
@@ -1242,13 +1243,15 @@ class DashboardHandler(BaseHTTPRequestHandler):
         pass
 
     def do_GET(self):
-        if self.path in ("/", "/index.html"):
+        # Strip query string so bookmarked URLs like /?range=all still match.
+        path = urlparse(self.path).path
+        if path in ("/", "/index.html"):
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
             self.wfile.write(HTML_TEMPLATE.encode("utf-8"))
 
-        elif self.path == "/api/data":
+        elif path == "/api/data":
             data = get_dashboard_data()
             body = json.dumps(data).encode("utf-8")
             self.send_response(200)
@@ -1262,7 +1265,8 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self.end_headers()
 
     def do_POST(self):
-        if self.path == "/api/rescan":
+        path = urlparse(self.path).path
+        if path == "/api/rescan":
             # Full rebuild: delete DB and rescan from scratch.
             # Pass DB_PATH / DEFAULT_PROJECTS_DIRS explicitly so tests that
             # patch the module globals are honored (scan's defaults are


### PR DESCRIPTION
## What

`DashboardHandler.do_GET` matches `self.path` against literal strings (`/`, `/index.html`, `/api/data`). `self.path` includes the query string, so URLs like `/?range=all` — the format the dashboard itself writes via `history.replaceState` for bookmarkable range/model filters — fall through to the 404 branch on hard-refresh or bookmark navigation.

## Repro

```bash
python3 cli.py dashboard
curl -o /dev/null -w "%{http_code}\n" http://localhost:8080/            # 200
curl -o /dev/null -w "%{http_code}\n" http://localhost:8080/?range=all  # 404 (bug)
```

## Fix

Split off the query string with `urlparse(self.path).path` before matching. Apply in both `do_GET` and `do_POST`. No new dependency — `urllib.parse` is stdlib.

## Test plan (smoke-tested locally)

| Request | Before | After |
|---|---|---|
| `GET /` | 200 | 200 |
| `GET /?range=all` | **404** | **200** |
| `GET /?range=7d` | 404 | 200 |
| `GET /api/data` | 200 | 200 |
| `GET /api/data?x=1` | 404 | 200 |
| `GET /nonexistent` | 404 | 404 |
