### PR TITLE
Fix dashboard hourly range filter

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
Fixes #126

This replaces the undefined \cutoff\ variable in the dashboard hourly aggregation filter with the existing \start\ / \end\ range bounds from \getRangeBounds(selectedRange)\.

I reproduced the issue locally: \cli.py stats\ showed usage data, but the dashboard rendered empty charts/tables due to \ReferenceError: cutoff is not defined\.

Tested with:

- \python -m py_compile cli.py dashboard.py\
- \python cli.py stats\
- \python cli.py dashboard --host 127.0.0.1 --port 18080\
- Verified dashboard renders data correctly for 30d and All ranges.