### PR TITLE
fix: undefined `cutoff` in applyFilter freezes dashboard at zero

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
## Summary

Commit 4bde661 (`feat: hourly activity distribution chart`) introduced a filter inside `applyFilter()` that references a `cutoff` variable:

```js
const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
  selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
);
```

But the earlier commit 7508369 (`feat: This Week, This Month, Previous Month range filters`) had removed the previous `const cutoff = getRangeCutoff(selectedRange)` declaration in favour of the new `{ start, end } = getRangeBounds(selectedRange)` API. The two commits together left `cutoff` as an undeclared identifier in `applyFilter`.

At runtime this throws `ReferenceError: cutoff is not defined` and interrupts `applyFilter` **before** `renderStats`, `renderDailyChart`, `renderHourlyChart`, `renderModelChart`, `renderProjectChart`, etc. run.

## User-visible symptom

- The dashboard appears to load (the `Updated: ...` meta refreshes, auto-refresh ticks, the filter UI is interactive).
- Every KPI stays at `0` and every chart is empty.
- `/api/data` still returns the full payload — the DB and the Python backend are fine.
- Nothing is shown in the UI to indicate the failure; the error is only visible in the browser DevTools console.

## Fix

Align the hourly filter with the daily / sessions filters that already use `{ start, end }` from `getRangeBounds`:

```js
const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
  selectedModels.has(r.model) && (!start || r.day >= start) && (!end || r.day <= end)
);
```

No behavioural change for any range — this evaluates to the same set of rows that the original `cutoff` predicate was intended to keep.

## Test plan

- [x] Reproduced on a ~5 000-turn local DB: all KPIs at zero, all charts empty, console shows `ReferenceError: cutoff is not defined`.
- [x] After the patch: KPIs, daily chart, hourly chart, model chart, project chart and Recent Sessions table all render correctly.
- [x] Verified across ranges: `This Week`, `This Month`, `Prev Month`, `7d`, `30d`, `90d`, `All`.
- [x] No new console warnings or errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)