### PR TITLE
Fix undefined 'cutoff' variable in applyFilter() that breaks chart rendering

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -742,7 +742,7 @@ function applyFilter() {
 
   // Hourly aggregation (filtered by model + range, then bucketed by UTC hour)
   const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
-    selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
+    selectedModels.has(r.model) && (!start || r.day >= start)
   );
   const hourlyAgg = aggregateHourly(hourlySrc, hourlyTZ);
 


### PR DESCRIPTION
Fixes #130

## What was wrong

`applyFilter()` referenced an undefined variable `cutoff` when filtering the hourly data:

```js
const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
  selectedModels.has(r.model) && (!cutoff || r.day >= cutoff)
);
```

`cutoff` is never declared in `applyFilter()`. This throws a `ReferenceError` in the browser, silently crashing the function before any of the chart render calls (`renderDailyChart`, `renderHourlyChart`, etc.) are reached. The result: all charts remain empty even though the API returns valid data and the model filter bar populates correctly.

## Fix

Replace `cutoff` with `start`, the correct variable declared at the top of `applyFilter()` via `getRangeBounds()`:

```js
const hourlySrc = (rawData.hourly_by_model || []).filter(r =>
  selectedModels.has(r.model) && (!start || r.day >= start)
);
```

One character change, one line.