### PR TITLE
fix: add explicit pricing for Opus 4.8 (claude-opus-4-8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Costs are calculated using **Anthropic API pricing as of April 2026** ([claude.c
 
 | Model | Input | Output | Cache Write | Cache Read |
 |-------|-------|--------|------------|-----------|
+| claude-opus-4-8 | $5.00/MTok | $25.00/MTok | $6.25/MTok | $0.50/MTok |
 | claude-opus-4-7 | $5.00/MTok | $25.00/MTok | $6.25/MTok | $0.50/MTok |
 | claude-opus-4-6 | $5.00/MTok | $25.00/MTok | $6.25/MTok | $0.50/MTok |
 | claude-sonnet-4-6 | $3.00/MTok | $15.00/MTok | $3.75/MTok | $0.30/MTok |

--- a/cli.py
+++ b/cli.py
@@ -17,6 +17,7 @@ from datetime import datetime, date, timedelta
 DB_PATH = Path.home() / ".claude" / "usage.db"
 
 PRICING = {
+    "claude-opus-4-8":   {"input": 5.00, "output": 25.00, "cache_read": 0.50, "cache_write": 6.25},
     "claude-opus-4-7":   {"input": 5.00, "output": 25.00, "cache_read": 0.50, "cache_write": 6.25},
     "claude-opus-4-6":   {"input": 5.00, "output": 25.00, "cache_read": 0.50, "cache_write": 6.25},
     "claude-opus-4-5":   {"input": 5.00, "output": 25.00, "cache_read": 0.50, "cache_write": 6.25},
@@ -39,7 +40,7 @@ def get_pricing(model):
     # Substring fallback: match model family by keyword
     m = model.lower()
     if "opus" in m:
-        return PRICING["claude-opus-4-7"]
+        return PRICING["claude-opus-4-8"]
     if "sonnet" in m:
         return PRICING["claude-sonnet-4-6"]
     if "haiku" in m:

--- a/dashboard.py
+++ b/dashboard.py
@@ -485,6 +485,7 @@ function tzDisplayName(tzMode) {
 
 // ── Pricing (Anthropic API, April 2026) ────────────────────────────────────
 const PRICING = {
+  'claude-opus-4-8':   { input:  5.00, output: 25.00, cache_write:  6.25, cache_read: 0.50 },
   'claude-opus-4-7':   { input:  5.00, output: 25.00, cache_write:  6.25, cache_read: 0.50 },
   'claude-opus-4-6':   { input:  5.00, output: 25.00, cache_write:  6.25, cache_read: 0.50 },
   'claude-opus-4-5':   { input:  5.00, output: 25.00, cache_write:  6.25, cache_read: 0.50 },
@@ -509,7 +510,7 @@ function getPricing(model) {
     if (model.startsWith(key)) return PRICING[key];
   }
   const m = model.toLowerCase();
-  if (m.includes('opus'))   return PRICING['claude-opus-4-7'];
+  if (m.includes('opus'))   return PRICING['claude-opus-4-8'];
   if (m.includes('sonnet')) return PRICING['claude-sonnet-4-6'];
   if (m.includes('haiku'))  return PRICING['claude-haiku-4-5'];
   return null;

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,12 +15,20 @@ class TestGetPricing(unittest.TestCase):
         self.assertEqual(p["output"], 25.00)
 
     def test_all_known_models_have_pricing(self):
-        for model in ("claude-opus-4-7", "claude-opus-4-6", "claude-opus-4-5",
+        for model in ("claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-opus-4-5",
                        "claude-sonnet-4-7", "claude-sonnet-4-6", "claude-sonnet-4-5",
                        "claude-haiku-4-7", "claude-haiku-4-6", "claude-haiku-4-5"):
             p = get_pricing(model)
             self.assertGreater(p["input"], 0, f"Missing input price for {model}")
             self.assertGreater(p["output"], 0, f"Missing output price for {model}")
+
+    def test_opus_4_8_has_explicit_entry(self):
+        """Regression guard for issue #133 — Opus 4.8 must be present, not just
+        resolved via the generic 'opus' substring fallback."""
+        self.assertIn("claude-opus-4-8", PRICING)
+        p = get_pricing("claude-opus-4-8")
+        self.assertEqual(p["input"], 5.00)
+        self.assertEqual(p["output"], 25.00)
 
     def test_opus_4_7_has_explicit_entry(self):
         """Regression guard for issue #61 — Opus 4.7 must be present."""


### PR DESCRIPTION
## Summary

Adds an explicit pricing entry for **Opus 4.8** (`claude-opus-4-8`), which was missing from both pricing tables. Closes #133.

Before this change, cost for `claude-opus-4-8` was only computed via the generic `opus` substring fallback, which returned the **4.7** rate. The numbers happened to be correct (4.8 has the same API pricing as 4.7), but:

- the newest/most-used Opus model wasn't listed explicitly like 4-7/4-6/4-5;
- if 4.8 were ever priced differently, costs would silently be wrong;
- the `opus` catch-all fallback pointed at a previous model.

## Changes

- `cli.py` — add `claude-opus-4-8` to `PRICING`; point the `opus` fallback at `claude-opus-4-8`
- `dashboard.py` — add `claude-opus-4-8` to the JS `PRICING`; point the `opus` fallback at `claude-opus-4-8`
- `README.md` — add the `claude-opus-4-8` row to the cost table
- `tests/test_cli.py` — add `claude-opus-4-8` to the known-models list + a regression guard (`test_opus_4_8_has_explicit_entry`)

Rates match Opus 4.7 (verified against [claude.com/pricing#api](https://claude.com/pricing#api)): `$5` input, `$25` output, `$0.50` cache read, `$6.25` cache write per MTok.

## Testing

- `python3 -m unittest discover -s tests` — all green (incl. the new guard and the existing cli↔dashboard pricing-parity tests).
