### PR TITLE
Make Rescan non-destructive — it silently wipes usage history

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -173,9 +173,6 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
     mask: url("icon.svg") no-repeat center / contain;
   }
   header .meta { color: var(--muted); font-size: 12px; text-align: right; line-height: 1.5; margin-right: 20px; }
-  #rescan-btn { background: var(--card); border: 1px solid var(--border); color: var(--muted); padding: 4px 12px; border-radius: 6px; cursor: pointer; font-size: 12px; margin-top: 4px; }
-  #rescan-btn:hover { color: var(--text); border-color: var(--accent); }
-  #rescan-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
   #filter-bar { background: var(--card); border-bottom: 1px solid var(--border); padding: 10px 24px; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
   .filter-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); white-space: nowrap; }
@@ -265,7 +262,6 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
     <h1>Claude Code Usage</h1>
   </div>
   <div class="meta" id="meta">Loading...</div>
-  <button id="rescan-btn" onclick="triggerRescan()" title="Rebuild the database from scratch by re-scanning all JSONL files. Use if data looks stale or costs seem wrong.">&#x21bb; Rescan</button>
 </header>
 
 <div id="filter-bar">
@@ -1389,22 +1385,6 @@ function exportProjectBranchCSV() {
   downloadCSV('projects_by_branch', header, rows);
 }
 
-// ── Rescan ────────────────────────────────────────────────────────────────
-async function triggerRescan() {
-  const btn = document.getElementById('rescan-btn');
-  btn.disabled = true;
-  btn.textContent = '\u21bb Scanning...';
-  try {
-    const resp = await fetch('/api/rescan', { method: 'POST' });
-    const d = await resp.json();
-    btn.textContent = '\u21bb Rescan (' + d.new + ' new, ' + d.updated + ' updated)';
-    await loadData();
-  } catch(e) {
-    btn.textContent = '\u21bb Rescan (error)';
-    console.error(e);
-  }
-  setTimeout(() => { btn.textContent = '\u21bb Rescan'; btn.disabled = false; }, 3000);
-}
 
 // ── Data loading ───────────────────────────────────────────────────────────
 async function loadData() {
@@ -1527,14 +1507,17 @@ class DashboardHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         path = urlparse(self.path).path
         if path == "/api/rescan":
-            # Full rebuild: delete DB and rescan from scratch.
+            # Append-only incremental scan -- does NOT delete the DB.
+            # The original implementation unlinked usage.db and rebuilt from
+            # scratch, which permanently discarded all history older than what
+            # Claude Code still keeps on disk (it prunes old transcripts on a
+            # rolling basis). scanner.scan() tracks processed files and only
+            # appends new turns, so a refresh never destroys history.
             # Pass DB_PATH / DEFAULT_PROJECTS_DIRS explicitly so tests that
             # patch the module globals are honored (scan's defaults are
             # frozen at def time and would otherwise target the real paths).
             import scanner
             db_path = DB_PATH
-            if db_path.exists():
-                db_path.unlink()
             result = scanner.scan(
                 db_path=db_path,
                 projects_dirs=scanner.DEFAULT_PROJECTS_DIRS,


### PR DESCRIPTION
## The problem

The **Rescan** button (and its `POST /api/rescan` handler) does a *full rebuild*: it `unlink()`s `usage.db` and re-scans from the JSONL transcripts on disk.

That is silent, unrecoverable data loss. Claude Code prunes old session transcripts on a rolling basis (`cleanupPeriodDays`), so on any given day `~/.claude/projects` only holds roughly the last few weeks. `usage.db` is **append-only**, which makes it the *only* place older history survives. Deleting it and rebuilding from disk therefore permanently discards every day older than the current on-disk retention window — with no warning and no backup. The tooltip actively invites the click ("Use if data looks stale or costs seem wrong").

### Repro
1. Run the tool for a while so `usage.db` accumulates history (e.g. a few months).
2. Claude Code, meanwhile, deletes transcripts older than its retention window.
3. Click **Rescan**.
4. All history older than what's still on disk is gone. In my case a one-month-old install with data back to mid-February was reduced to the last ~30 days the instant Rescan ran.

## The fix

- Remove the **Rescan** button, its click handler, and its CSS.
- Keep `POST /api/rescan`, but make it **append-only**: it now calls `scanner.scan()` **without** unlinking the DB. `scanner.scan()` already tracks processed files and only inserts new turns, so a refresh updates the DB without ever destroying history.

Net diff is small (+6 / −23). All **103** existing tests pass (including `test_api_rescan_returns_json`).

## Note

I kept `/api/rescan` as a safe incremental refresh rather than removing the endpoint outright, since it's the more conservative change. If you'd rather drop the endpoint entirely (the button was its only caller), or instead keep a destructive rebuild but back the DB up first, happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
