### PR TITLE
fix(cli): migrate old-schema DB on read so today/week/stats don't crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.5.5 — TBD
+
+### Scanner / CLI
+
+- The `today`, `week`, and `stats` commands now run the idempotent schema migration when they open the database, so reading before the next `scan` no longer crashes with `sqlite3.OperationalError: no such column: is_subagent` on a database created before subagent tracking existed. The dashboard already did this; the CLI read path now matches.
+
 ## v1.5.4 — 2026-07-01
 
 ### Dashboard

--- a/cli.py
+++ b/cli.py
@@ -83,7 +83,17 @@ def require_db():
     if not DB_PATH.exists():
         print("Database not found. Run: python cli.py scan")
         sys.exit(1)
-    return sqlite3.connect(DB_PATH)
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    # Ensure the schema is current before querying. The read commands query the
+    # `agents` table and the `is_subagent`/`agent_id` columns, so a pre-existing
+    # DB from before those were added would raise "no such column" when a read
+    # command runs before the next scan migrates it. init_db is idempotent
+    # (CREATE ... IF NOT EXISTS + additive column checks), so this is a cheap
+    # no-op once migrated. Mirrors get_dashboard_data in dashboard.py.
+    from scanner import init_db
+    init_db(conn)
+    return conn
 
 
 # ── Commands ──────────────────────────────────────────────────────────────────

--- a/scanner.py
+++ b/scanner.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 # runtime version has to live here as a constant. Keep this in lockstep with the
 # top CHANGELOG heading and vscode-extension/package.json (a parity test guards
 # all three; see tests/test_version.py).
-VERSION = "1.5.4"
+VERSION = "1.5.5"
 
 PROJECTS_DIR = Path.home() / ".claude" / "projects"
 XCODE_PROJECTS_DIR = Path.home() / "Library" / "Developer" / "Xcode" / "CodingAssistant" / "ClaudeAgentConfig" / "projects"

--- a/tests/test_cli_subagent.py
+++ b/tests/test_cli_subagent.py
@@ -64,5 +64,56 @@ class TestCliSubagentLines(unittest.TestCase):
         self.assertIn("Subagent tokens:", out)
 
 
+class TestCliReadCommandsMigrateOldSchema(unittest.TestCase):
+    """A DB created before the subagent columns existed must not crash the read
+    commands: require_db runs the idempotent init_db migration on open."""
+
+    def setUp(self):
+        import sqlite3
+        self.db_path = Path(tempfile.mkdtemp()) / "usage.db"
+        today_ts = date.today().isoformat() + "T10:00:00Z"
+        # Pre-migration schema: turns has no is_subagent/agent_id, and there is
+        # no `agents` table.
+        conn = sqlite3.connect(self.db_path)
+        conn.executescript("""
+            CREATE TABLE turns (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT,
+                timestamp TEXT, model TEXT, input_tokens INTEGER,
+                output_tokens INTEGER, cache_read_tokens INTEGER,
+                cache_creation_tokens INTEGER, tool_name TEXT, cwd TEXT,
+                message_id TEXT);
+        """)
+        conn.execute(
+            "INSERT INTO turns (session_id, timestamp, model, input_tokens, "
+            "output_tokens, cache_read_tokens, cache_creation_tokens, message_id) "
+            "VALUES ('s1', ?, 'claude-opus-4-8', 100, 200, 0, 0, 'm1')",
+            (today_ts,))
+        conn.commit()
+        conn.close()
+        self._orig_db = cli.DB_PATH
+        cli.DB_PATH = self.db_path
+
+    def tearDown(self):
+        cli.DB_PATH = self._orig_db
+
+    def test_today_does_not_crash_on_old_schema(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cli.cmd_today()
+        self.assertIn("Subagent tokens:", buf.getvalue())
+
+    def test_week_does_not_crash_on_old_schema(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cli.cmd_week()
+        self.assertTrue(buf.getvalue())
+
+    def test_stats_does_not_crash_on_old_schema(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cli.cmd_stats()
+        self.assertIn("Subagent turns:", buf.getvalue())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "claude-usage-phuryn",
   "displayName": "Claude Code Usage by Paweł Huryn",
   "description": "Embed your Claude Code usage dashboard (token counts, costs, sessions, projects) directly inside VS Code. Reads local JSONL transcripts, no API calls.",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "publisher": "PawelHuryn",
   "author": {
     "name": "Paweł Huryn",


### PR DESCRIPTION
## What

`today`, `week`, and `stats` crash on an existing database that predates subagent tracking, until the next `scan` runs:

```
sqlite3.OperationalError: no such column: is_subagent
```

## Why

The `is_subagent` / `agent_id` columns (and the `agents` table) are added by `init_db()`, which only runs during `scan`. The read commands open the DB via `require_db()` and query those columns directly, so upgrading and running `today` before `scan` hits the missing column. `dashboard.py`'s `get_dashboard_data()` already guards against this by calling the idempotent `init_db()` on open. This applies the same fix to the CLI read path.

## Change

- `require_db()` runs `init_db(conn)` (idempotent: `CREATE ... IF NOT EXISTS` plus additive column checks) before returning the connection.
- Regression test: a pre-migration DB no longer crashes `today` / `week` / `stats`.

## Testing

- Reproduced the crash on a hand-built old-schema DB, confirmed fixed.
- New test fails without the change, passes with it.
- Full suite: 147 passed.