### PR TITLE
feat(dashboard): make the 30s auto-refresh ingest new usage (revives #59)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -417,7 +417,13 @@ def cmd_dashboard(projects_dir=None, host=None, port=None, no_browser=False, sur
 
     def background_scan():
         print("Scanning in the background...")
-        scan(projects_dir=projects_dir)
+        # Hold the dashboard's rescan lock so the client's 30s auto-rescan
+        # (and the manual button) gets an instant {"busy": true} during the
+        # cold startup scan instead of scanning the same backlog concurrently.
+        import dashboard
+
+        with dashboard.RESCAN_LOCK:
+            scan(projects_dir=projects_dir)
         print("Background scan complete.")
 
     threading.Thread(target=background_scan, daemon=True).start()

--- a/dashboard.py
+++ b/dashboard.py
@@ -5,6 +5,7 @@ dashboard.py - Local web dashboard served on localhost:8080.
 import json
 import os
 import sqlite3
+import threading
 from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 from urllib.parse import urlparse
 from pathlib import Path
@@ -23,6 +24,10 @@ DB_PATH = Path(os.environ.get("CLAUDE_USAGE_DB", Path.home() / ".claude" / "usag
 # would misfire there because the Marketplace publish lags the GitHub release).
 SURFACE = "web"
 
+# Serializes /api/rescan handlers (see do_POST). Module-level so every
+# ThreadingHTTPServer request thread shares the one lock.
+RESCAN_LOCK = threading.Lock()
+
 
 def get_dashboard_data(db_path=DB_PATH):
     if not db_path.exists():
@@ -30,9 +35,12 @@ def get_dashboard_data(db_path=DB_PATH):
 
     conn = sqlite3.connect(db_path)
     # The dashboard reads while a background scan may be committing (cmd_dashboard
-    # serves first, scans in a background thread; /api/rescan scans in-process too).
-    # Wait briefly for write locks instead of raising "database is locked".
-    conn.execute("PRAGMA busy_timeout = 5000")
+    # serves first, scans in a background thread; /api/rescan scans in-process too,
+    # now every 30s via the client's auto-rescan tick). Match the 30s writer
+    # timeout in scanner.get_db: a read that waits out a long commit still
+    # answers, while a 5s cap could make /api/data error mid-scan and silently
+    # skip that refresh.
+    conn.execute("PRAGMA busy_timeout = 30000")
     conn.row_factory = sqlite3.Row
     # Ensure the schema is current before querying. cmd_dashboard binds and serves
     # *before* its background scan runs init_db, so on the first load after an
@@ -1907,7 +1915,11 @@ async function triggerRescan() {
   try {
     const resp = await fetch('/api/rescan', { method: 'POST' });
     const d = await resp.json();
-    btn.textContent = '\u21bb Rescan (' + d.new + ' new, ' + d.updated + ' updated)';
+    // "busy" = another scan (auto-rescan tick, other tab, startup scan) holds
+    // the server-side lock; its results land in the DB, so just re-read.
+    btn.textContent = d.busy
+      ? '\u21bb Rescan (already scanning)'
+      : '\u21bb Rescan (' + d.new + ' new, ' + d.updated + ' updated)';
     await loadData();
   } catch(e) {
     btn.textContent = '\u21bb Rescan (error)';
@@ -1961,10 +1973,32 @@ async function loadData() {
 }
 
 let autoRefreshTimer = null;
+let autoRescanInFlight = false;
+async function autoRefreshTick() {
+  // Ingest before re-reading: /api/data is a pure DB read, so a bare loadData
+  // poll only re-renders data from the last scan — fresh usage would never
+  // appear until the user pressed Rescan or restarted the server. The scan is
+  // incremental (per-file mtime skip), so a no-change tick is cheap. The
+  // in-flight guard keeps a slow scan from stacking ticks behind it; a
+  // guarded tick still loadData()s so partial commits from a long-running
+  // scan (e.g. the cold startup backlog) keep rendering progressively.
+  if (!autoRescanInFlight) {
+    autoRescanInFlight = true;
+    try {
+      await fetch('/api/rescan', { method: 'POST' });
+    } catch(e) {
+      // Scan failed or server unreachable — loadData below still renders
+      // whatever the DB has and surfaces its own errors.
+    } finally {
+      autoRescanInFlight = false;
+    }
+  }
+  await loadData();
+}
 function scheduleAutoRefresh() {
   if (autoRefreshTimer) { clearInterval(autoRefreshTimer); autoRefreshTimer = null; }
   if (rangeIncludesToday(selectedRange)) {
-    autoRefreshTimer = setInterval(loadData, 30000);
+    autoRefreshTimer = setInterval(autoRefreshTick, 30000);
   }
 }
 
@@ -2275,14 +2309,28 @@ class DashboardHandler(BaseHTTPRequestHandler):
             # Pass DB_PATH / DEFAULT_PROJECTS_DIRS explicitly so tests that
             # patch the module globals are honored (scan's defaults are
             # frozen at def time and would otherwise target the real paths).
-            import scanner
-            db_path = DB_PATH
-            result = scanner.scan(
-                db_path=db_path,
-                projects_dirs=scanner.DEFAULT_PROJECTS_DIRS,
-                verbose=False,
-            )
-            body = json.dumps(result).encode("utf-8")
+            #
+            # RESCAN_LOCK serializes scans within this process: the client
+            # auto-rescans every 30s (plus the manual button, times however
+            # many tabs are open), and ThreadingHTTPServer would happily run
+            # them all concurrently. Overlapping scans are safe for data
+            # (message_id dedupe + the sessions recompute) but contend on the
+            # SQLite write lock; skipping with {"busy": true} is cheaper and
+            # the next 30s tick picks up anything missed.
+            if not RESCAN_LOCK.acquire(blocking=False):
+                body = json.dumps({"busy": True}).encode("utf-8")
+            else:
+                try:
+                    import scanner
+                    db_path = DB_PATH
+                    result = scanner.scan(
+                        db_path=db_path,
+                        projects_dirs=scanner.DEFAULT_PROJECTS_DIRS,
+                        verbose=False,
+                    )
+                finally:
+                    RESCAN_LOCK.release()
+                body = json.dumps(result).encode("utf-8")
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(body)))

--- a/scanner.py
+++ b/scanner.py
@@ -42,7 +42,11 @@ def get_db(db_path=DB_PATH):
     # Ensure the parent directory exists — on a fresh install or CI runner
     # ~/.claude may not yet exist, and sqlite3.connect needs the parent dir.
     Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(db_path)
+    # timeout raised from the 5s default: scans can now run concurrently with
+    # each other (dashboard auto-rescan vs an external `cli.py scan`) and the
+    # end-of-scan sessions recompute can hold the write lock longer than 5s on
+    # a big DB — wait it out rather than raise "database is locked".
+    conn = sqlite3.connect(db_path, timeout=30.0)
     conn.row_factory = sqlite3.Row
     return conn
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -377,6 +377,31 @@ class TestDashboardHTTP(unittest.TestCase):
         self.assertEqual(turn_count, 1, "rescan must not delete existing turns")
         self.assertEqual(sess_count, 1, "rescan must not delete existing sessions")
 
+    def test_api_rescan_busy_when_scan_in_flight(self):
+        # The client auto-rescans every 30s (autoRefreshTick), so overlapping
+        # scans are now routine — a tick landing while the startup scan or
+        # another tab's rescan holds RESCAN_LOCK must get an immediate
+        # {"busy": true} instead of a second concurrent scan.
+        import dashboard as _d
+        url = f"http://127.0.0.1:{self.port}/api/rescan"
+        req = urllib.request.Request(url, method="POST")
+
+        acquired = _d.RESCAN_LOCK.acquire(blocking=False)
+        self.assertTrue(acquired, "test requires the lock to be free")
+        try:
+            with urllib.request.urlopen(req) as resp:
+                self.assertEqual(resp.status, 200)
+                data = json.loads(resp.read())
+            self.assertEqual(data, {"busy": True})
+        finally:
+            _d.RESCAN_LOCK.release()
+
+        # Lock released → the next rescan runs normally.
+        with urllib.request.urlopen(req) as resp:
+            data = json.loads(resp.read())
+        self.assertIn("new", data)
+        self.assertNotIn("busy", data)
+
     def test_404_for_unknown_path(self):
         url = f"http://127.0.0.1:{self.port}/nonexistent"
         try:
@@ -441,6 +466,21 @@ class TestHTMLTemplate(unittest.TestCase):
         self.assertIn("'today': 1", HTML_TEMPLATE)
         # Bounds case: today returns start === end === today's ISO date
         self.assertIn("range === 'today'", HTML_TEMPLATE)
+
+    def test_auto_refresh_rescans_before_reading(self):
+        """The 30s auto-refresh must ingest new usage, not just re-read the DB:
+        the timer fires autoRefreshTick (never bare loadData), and the tick
+        POSTs /api/rescan before loadData. Without this, fresh usage only
+        appears after a manual Rescan click or a server restart."""
+        self.assertIn("setInterval(autoRefreshTick, 30000)", HTML_TEMPLATE)
+        self.assertNotIn("setInterval(loadData", HTML_TEMPLATE)
+        tick = HTML_TEMPLATE.split("async function autoRefreshTick()")[1]
+        tick = tick.split("function scheduleAutoRefresh(")[0]
+        self.assertIn("'/api/rescan'", tick)
+        self.assertIn("await loadData()", tick)
+        # Order matters: scan first, then read — reversed, the UI would always
+        # render one scan (30s) behind.
+        self.assertLess(tick.index("'/api/rescan'"), tick.index("await loadData()"))
 
     def test_app_config_placeholder_present(self):
         """The head carries the server-substituted config placeholder and the


### PR DESCRIPTION
## Problem

With the dashboard open, fresh Claude Code usage never appears. The 30-second auto-refresh only re-fetches `/api/data`, which is a pure read of `usage.db` — nothing on the server re-scans the transcript JSONL after the single startup background scan. Users end up clicking **⟳ Rescan** every time, or (more commonly, if they don't realize the button is the ingestion path) Ctrl+C-ing and relaunching the server. This is the limitation noted in the #138 discussion: *"Auto-refresh only re-reads /api/data and never scans, so the button is the only in-session way to ingest new turns."*

## Fix

- The 30s timer now fires `autoRefreshTick()`, which POSTs `/api/rescan` — the same incremental, non-destructive scan the button runs — and then re-reads `/api/data`. An in-flight guard keeps ticks from stacking behind a slow scan, and a guarded tick still re-reads, so a long scan renders progressively (preserving the serve-first/scan-behind cold-start behavior of `cmd_dashboard`).
- A module-level `RESCAN_LOCK` serializes scans server-side: a rescan arriving while another runs (second tab, tick racing the manual button) gets an immediate `{"busy": true}` instead of a concurrent scan, and `triggerRescan` shows *"Rescan (already scanning)"* for that case. `cmd_dashboard`'s startup scan holds the same lock, so a tick during a cold start skips instead of double-scanning the backlog.
- SQLite lock waits raised 5s → 30s on both sides (`scanner.get_db` connect timeout, the dashboard's read `busy_timeout`): scans now routinely run beside reads, and the end-of-scan sessions recompute can hold the write lock longer than 5s on a big DB.
- Tests: `/api/rescan` busy path, plus template guards pinning the timer to `autoRefreshTick` (never bare `loadData`) and the scan-before-read order inside the tick.

## Verification

- Full suite passes on top of v1.5.5 (149 tests), including the three new ones.
- Live sandboxed run (fake `HOME` + `CLAUDE_USAGE_DB`, real server): turns appended to a session JSONL after startup were ingested by the tick's `POST /api/rescan` and reflected in `/api/data` with exact token totals; the busy path returns `{"busy": true}` while the lock is held and resumes normally after.
- Both embedded `<script>` blocks of the served page pass `node --check`.

## History

#59 proposed exactly this (auto-refresh running an incremental scan) back in April and was closed — understandably, since `/api/rescan` was a destructive full rebuild at the time, and auto-firing it would have been dangerous. #138 → `97e1d91` (v1.2.6) made the endpoint incremental and append-only, which is what makes an auto-firing rescan safe now. This PR revives #59's intent on that foundation.

## Notes

- `CHANGELOG.md` deliberately untouched (version headings accumulate on `DEV`); suggested bullet for the next section:
  > Made the 30s auto-refresh actually ingest new usage: each tick now runs the same incremental scan as the Rescan button before re-reading the DB, so fresh turns appear without clicking Rescan or restarting the server. Concurrent scans are serialized behind a rescan lock.
- One possible follow-up (not in this PR to keep it minimal): the end-of-scan sessions recompute is unscoped, so on very large DBs (hundreds of thousands of turns) an active tick rewrites every `sessions` row (~0.8s measured at 500k turns). Scoping it to sessions touched by the scan would make active ticks O(delta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
