### PR TITLE
Price 1-hour-TTL cache writes at 2x input (fixes #162)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -55,15 +55,31 @@ def get_pricing(model):
         return PRICING["claude-haiku-4-5"]
     return None
 
-def calc_cost(model, inp, out, cache_read, cache_creation):
+# Anthropic bills cache writes at 1.25x base input for the 5-minute TTL and 2x
+# for the 1-hour TTL. "cache_write" in PRICING is the 5-minute rate.
+CACHE_WRITE_1H_MULTIPLIER = 2.0
+
+
+def calc_cost(model, inp, out, cache_read, cache_creation, cache_creation_1h=0):
+    """Cost in USD.
+
+    ``cache_creation`` is the total cache-creation tokens and
+    ``cache_creation_1h`` the portion written with a 1-hour TTL, so the
+    5-minute portion is the difference. Callers that omit
+    ``cache_creation_1h`` bill the whole bucket at the 5-minute rate, which
+    preserves the previous behaviour for rows recorded before the split.
+    """
     p = get_pricing(model)
     if not p:
         return 0.0
+    cache_creation_1h = max(0, min(cache_creation_1h, cache_creation))
+    cache_creation_5m = cache_creation - cache_creation_1h
     return (
-        inp            * p["input"]       / 1_000_000 +
-        out            * p["output"]      / 1_000_000 +
-        cache_read     * p["cache_read"]  / 1_000_000 +
-        cache_creation * p["cache_write"] / 1_000_000
+        inp               * p["input"]       / 1_000_000 +
+        out               * p["output"]      / 1_000_000 +
+        cache_read        * p["cache_read"]  / 1_000_000 +
+        cache_creation_5m * p["cache_write"] / 1_000_000 +
+        cache_creation_1h * p["input"] * CACHE_WRITE_1H_MULTIPLIER / 1_000_000
     )
 
 def fmt(n):
@@ -114,6 +130,7 @@ def cmd_today():
             SUM(output_tokens)         as out,
             SUM(cache_read_tokens)     as cr,
             SUM(cache_creation_tokens) as cc,
+            SUM(cache_creation_1h_tokens) as cc1h,
             COUNT(*)                   as turns
         FROM turns
         WHERE substr(timestamp, 1, 10) = ?
@@ -150,7 +167,7 @@ def cmd_today():
     total_cost = 0.0
 
     for r in rows:
-        cost = calc_cost(r["model"], r["inp"] or 0, r["out"] or 0, r["cr"] or 0, r["cc"] or 0)
+        cost = calc_cost(r["model"], r["inp"] or 0, r["out"] or 0, r["cr"] or 0, r["cc"] or 0, r["cc1h"] or 0)
         total_cost += cost
         total_inp += r["inp"] or 0
         total_out += r["out"] or 0
@@ -187,6 +204,7 @@ def cmd_week():
             SUM(output_tokens)         as out,
             SUM(cache_read_tokens)     as cr,
             SUM(cache_creation_tokens) as cc,
+            SUM(cache_creation_1h_tokens) as cc1h,
             COUNT(*)                   as turns
         FROM turns
         WHERE substr(timestamp, 1, 10) BETWEEN ? AND ?
@@ -200,6 +218,7 @@ def cmd_week():
             SUM(output_tokens)         as out,
             SUM(cache_read_tokens)     as cr,
             SUM(cache_creation_tokens) as cc,
+            SUM(cache_creation_1h_tokens) as cc1h,
             COUNT(*)                   as turns
         FROM turns
         WHERE substr(timestamp, 1, 10) BETWEEN ? AND ?
@@ -232,7 +251,7 @@ def cmd_week():
         bucket["turns"] += r["turns"]
         bucket["inp"]   += r["inp"] or 0
         bucket["out"]   += r["out"] or 0
-        bucket["cost"]  += calc_cost(r["model"], r["inp"] or 0, r["out"] or 0, r["cr"] or 0, r["cc"] or 0)
+        bucket["cost"]  += calc_cost(r["model"], r["inp"] or 0, r["out"] or 0, r["cr"] or 0, r["cc"] or 0, r["cc1h"] or 0)
 
     print("  By Day:")
     for i in range(7):
@@ -246,7 +265,7 @@ def cmd_week():
     total_inp = total_out = total_cr = total_cc = total_turns = 0
     total_cost = 0.0
     for r in by_model:
-        cost = calc_cost(r["model"], r["inp"] or 0, r["out"] or 0, r["cr"] or 0, r["cc"] or 0)
+        cost = calc_cost(r["model"], r["inp"] or 0, r["out"] or 0, r["cr"] or 0, r["cc"] or 0, r["cc1h"] or 0)
         total_cost  += cost
         total_inp   += r["inp"] or 0
         total_out   += r["out"] or 0
@@ -285,6 +304,7 @@ def cmd_stats():
             SUM(output_tokens)            as out,
             SUM(cache_read_tokens)        as cr,
             SUM(cache_creation_tokens)    as cc,
+            SUM(cache_creation_1h_tokens) as cc1h,
             COUNT(*)                      as turns
         FROM turns
     """).fetchone()
@@ -297,6 +317,7 @@ def cmd_stats():
             SUM(output_tokens)         as out,
             SUM(cache_read_tokens)     as cr,
             SUM(cache_creation_tokens) as cc,
+            SUM(cache_creation_1h_tokens) as cc1h,
             COUNT(*)                   as turns,
             COUNT(DISTINCT session_id) as sessions
         FROM turns
@@ -346,7 +367,7 @@ def cmd_stats():
 
     # Build total cost across all models
     total_cost = sum(
-        calc_cost(r["model"], r["inp"] or 0, r["out"] or 0, r["cr"] or 0, r["cc"] or 0)
+        calc_cost(r["model"], r["inp"] or 0, r["out"] or 0, r["cr"] or 0, r["cc"] or 0, r["cc1h"] or 0)
         for r in by_model
     )
 
@@ -373,7 +394,7 @@ def cmd_stats():
 
     print("  By Model:")
     for r in by_model:
-        cost = calc_cost(r["model"], r["inp"] or 0, r["out"] or 0, r["cr"] or 0, r["cc"] or 0)
+        cost = calc_cost(r["model"], r["inp"] or 0, r["out"] or 0, r["cr"] or 0, r["cc"] or 0, r["cc1h"] or 0)
         print(f"    {r['model']:<30}  sessions={r['sessions']:<4}  turns={fmt(r['turns'] or 0):<6}  "
               f"in={fmt(r['inp'] or 0):<8}  out={fmt(r['out'] or 0):<8}  cost={fmt_cost(cost)}")
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -63,6 +63,7 @@ def get_dashboard_data(db_path=DB_PATH):
             SUM(output_tokens)         as output,
             SUM(cache_read_tokens)     as cache_read,
             SUM(cache_creation_tokens) as cache_creation,
+            SUM(cache_creation_1h_tokens) as cache_creation_1h,
             COUNT(*)                   as turns
         FROM turns
         GROUP BY day, COALESCE(NULLIF(model, ''), 'unknown')
@@ -76,6 +77,7 @@ def get_dashboard_data(db_path=DB_PATH):
         "output":         r["output"] or 0,
         "cache_read":     r["cache_read"] or 0,
         "cache_creation": r["cache_creation"] or 0,
+        "cache_creation_1h": r["cache_creation_1h"] or 0,
         "turns":          r["turns"] or 0,
     } for r in daily_rows]
 
@@ -158,6 +160,7 @@ def get_dashboard_data(db_path=DB_PATH):
             SUM(t.output_tokens)                     as output,
             SUM(t.cache_read_tokens)                 as cache_read,
             SUM(t.cache_creation_tokens)             as cache_creation,
+            SUM(t.cache_creation_1h_tokens)          as cache_creation_1h,
             COUNT(DISTINCT t.agent_id)               as dispatches,
             COUNT(*)                                 as turns
         FROM turns t
@@ -175,6 +178,7 @@ def get_dashboard_data(db_path=DB_PATH):
         "output":         r["output"] or 0,
         "cache_read":     r["cache_read"] or 0,
         "cache_creation": r["cache_creation"] or 0,
+        "cache_creation_1h": r["cache_creation_1h"] or 0,
         "dispatches":     r["dispatches"] or 0,
         "turns":          r["turns"] or 0,
     } for r in subagent_daily_rows]
@@ -190,6 +194,7 @@ def get_dashboard_data(db_path=DB_PATH):
             SUM(t.output_tokens)                     as output,
             SUM(t.cache_read_tokens)                 as cache_read,
             SUM(t.cache_creation_tokens)             as cache_creation,
+            SUM(t.cache_creation_1h_tokens)          as cache_creation_1h,
             COUNT(*)                                 as turns,
             a.dispatched_in_session                  as parent_session,
             a.total_duration_ms                      as duration_ms,
@@ -213,6 +218,7 @@ def get_dashboard_data(db_path=DB_PATH):
         "output":         r["output"] or 0,
         "cache_read":     r["cache_read"] or 0,
         "cache_creation": r["cache_creation"] or 0,
+        "cache_creation_1h": r["cache_creation_1h"] or 0,
         "turns":          r["turns"] or 0,
         "duration_ms":    r["duration_ms"],
         "tool_uses":      r["tool_uses"],
@@ -770,15 +776,24 @@ function getPricing(model) {
   return null;
 }
 
-function calcCost(model, inp, out, cacheRead, cacheCreation) {
+// Cache writes bill at 1.25x base input for the 5-minute TTL (p.cache_write)
+// and 2x for the 1-hour TTL. cacheCreation is the total and cacheCreation1h
+// the 1-hour portion, so the remainder is the 5-minute portion. Omitting the
+// last argument bills everything at the 5-minute rate, as before.
+const CACHE_WRITE_1H_MULTIPLIER = 2.0;
+
+function calcCost(model, inp, out, cacheRead, cacheCreation, cacheCreation1h = 0) {
   if (!isBillable(model)) return 0;
   const p = getPricing(model);
   if (!p) return 0;
+  const cc1h = Math.max(0, Math.min(cacheCreation1h, cacheCreation));
+  const cc5m = cacheCreation - cc1h;
   return (
-    inp           * p.input       / 1e6 +
-    out           * p.output      / 1e6 +
-    cacheRead     * p.cache_read  / 1e6 +
-    cacheCreation * p.cache_write / 1e6
+    inp       * p.input       / 1e6 +
+    out       * p.output      / 1e6 +
+    cacheRead * p.cache_read  / 1e6 +
+    cc5m      * p.cache_write / 1e6 +
+    cc1h      * p.input * CACHE_WRITE_1H_MULTIPLIER / 1e6
   );
 }
 
@@ -1149,8 +1164,8 @@ function sortSessions(sessions) {
   return [...sessions].sort((a, b) => {
     let av, bv;
     if (sessionSortCol === 'cost') {
-      av = calcCost(a.model, a.input, a.output, a.cache_read, a.cache_creation);
-      bv = calcCost(b.model, b.input, b.output, b.cache_read, b.cache_creation);
+      av = calcCost(a.model, a.input, a.output, a.cache_read, a.cache_creation, a.cache_creation_1h);
+      bv = calcCost(b.model, b.input, b.output, b.cache_read, b.cache_creation, b.cache_creation_1h);
     } else if (sessionSortCol === 'duration_min') {
       av = parseFloat(a.duration_min) || 0;
       bv = parseFloat(b.duration_min) || 0;
@@ -1697,8 +1712,8 @@ function sortModels(byModel) {
   return [...byModel].sort((a, b) => {
     let av, bv;
     if (modelSortCol === 'cost') {
-      av = calcCost(a.model, a.input, a.output, a.cache_read, a.cache_creation);
-      bv = calcCost(b.model, b.input, b.output, b.cache_read, b.cache_creation);
+      av = calcCost(a.model, a.input, a.output, a.cache_read, a.cache_creation, a.cache_creation_1h);
+      bv = calcCost(b.model, b.input, b.output, b.cache_read, b.cache_creation, b.cache_creation_1h);
     } else {
       av = a[modelSortCol] ?? 0;
       bv = b[modelSortCol] ?? 0;

--- a/scanner.py
+++ b/scanner.py
@@ -73,6 +73,7 @@ def init_db(conn):
             output_tokens           INTEGER DEFAULT 0,
             cache_read_tokens       INTEGER DEFAULT 0,
             cache_creation_tokens   INTEGER DEFAULT 0,
+            cache_creation_1h_tokens INTEGER DEFAULT 0,
             tool_name               TEXT,
             cwd                     TEXT,
             message_id              TEXT,
@@ -115,6 +116,7 @@ def init_db(conn):
     # Subagent attribution columns (added in a later schema version)
     _ensure_column(conn, "turns", "is_subagent", "INTEGER DEFAULT 0")
     _ensure_column(conn, "turns", "agent_id", "TEXT")
+    _ensure_column(conn, "turns", "cache_creation_1h_tokens", "INTEGER DEFAULT 0")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_turns_subagent ON turns(is_subagent)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_turns_agent_id ON turns(agent_id)")
     # Session topic (from custom-title / ai-title records; added in a later
@@ -406,6 +408,13 @@ def parse_jsonl_file(filepath):
                     output_tokens = usage.get("output_tokens", 0) or 0
                     cache_read = usage.get("cache_read_input_tokens", 0) or 0
                     cache_creation = usage.get("cache_creation_input_tokens", 0) or 0
+                    # Cache writes bill at 1.25x input for the 5-minute TTL and 2x
+                    # for the 1-hour TTL. Older logs carry no breakdown, in which
+                    # case the whole bucket stays on the 5-minute rate as before.
+                    _cc_breakdown = usage.get("cache_creation") or {}
+                    cache_creation_1h = _cc_breakdown.get("ephemeral_1h_input_tokens", 0) or 0
+                    if cache_creation_1h > cache_creation:
+                        cache_creation_1h = cache_creation
 
                     # Only record turns that have actual token usage
                     if input_tokens + output_tokens + cache_read + cache_creation == 0:
@@ -429,6 +438,7 @@ def parse_jsonl_file(filepath):
                         "output_tokens": output_tokens,
                         "cache_read_tokens": cache_read,
                         "cache_creation_tokens": cache_creation,
+                        "cache_creation_1h_tokens": cache_creation_1h,
                         "tool_name": tool_name,
                         "cwd": cwd,
                         "message_id": message_id,
@@ -560,13 +570,14 @@ def insert_turns(conn, turns):
     conn.executemany("""
         INSERT OR IGNORE INTO turns
             (session_id, timestamp, model, input_tokens, output_tokens,
-             cache_read_tokens, cache_creation_tokens, tool_name, cwd, message_id,
-             is_subagent, agent_id)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             cache_read_tokens, cache_creation_tokens, cache_creation_1h_tokens,
+             tool_name, cwd, message_id, is_subagent, agent_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """, [
         (t["session_id"], t["timestamp"], t["model"],
          t["input_tokens"], t["output_tokens"],
          t["cache_read_tokens"], t["cache_creation_tokens"],
+         t.get("cache_creation_1h_tokens", 0),
          t["tool_name"], t["cwd"], t.get("message_id", ""),
          t.get("is_subagent", 0), t.get("agent_id"))
         for t in turns
@@ -732,6 +743,13 @@ def scan(projects_dir=None, projects_dirs=None, db_path=DB_PATH, verbose=True):
                             output_tokens = usage.get("output_tokens", 0) or 0
                             cache_read = usage.get("cache_read_input_tokens", 0) or 0
                             cache_creation = usage.get("cache_creation_input_tokens", 0) or 0
+                            # Cache writes bill at 1.25x input for the 5-minute TTL and 2x
+                            # for the 1-hour TTL. Older logs carry no breakdown, in which
+                            # case the whole bucket stays on the 5-minute rate as before.
+                            _cc_breakdown = usage.get("cache_creation") or {}
+                            cache_creation_1h = _cc_breakdown.get("ephemeral_1h_input_tokens", 0) or 0
+                            if cache_creation_1h > cache_creation:
+                                cache_creation_1h = cache_creation
 
                             if input_tokens + output_tokens + cache_read + cache_creation == 0:
                                 continue
@@ -753,6 +771,7 @@ def scan(projects_dir=None, projects_dirs=None, db_path=DB_PATH, verbose=True):
                                 "output_tokens": output_tokens,
                                 "cache_read_tokens": cache_read,
                                 "cache_creation_tokens": cache_creation,
+                                "cache_creation_1h_tokens": cache_creation_1h,
                                 "tool_name": tool_name,
                                 "cwd": cwd,
                                 "message_id": message_id,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -150,6 +150,41 @@ class TestCalcCost(unittest.TestCase):
         cost = calc_cost("claude-opus-4-6", 0, 0, 0, 0)
         self.assertEqual(cost, 0.0)
 
+    def test_1h_cache_writes_bill_at_double_input(self):
+        """1-hour TTL cache writes bill at 2x input, not the 5-minute rate."""
+        # 1M tokens, all 1-hour TTL. Opus input is $5/MTok, so 2x = $10.
+        cost = calc_cost("claude-opus-4-6", 0, 0, 0, 1_000_000, 1_000_000)
+        self.assertAlmostEqual(cost, 10.00, places=6)
+
+    def test_5m_cache_writes_unchanged(self):
+        """With no 1-hour portion, pricing matches the old behaviour exactly."""
+        cost = calc_cost("claude-opus-4-6", 0, 0, 0, 1_000_000, 0)
+        self.assertAlmostEqual(cost, 6.25, places=6)
+
+    def test_omitting_1h_argument_is_backwards_compatible(self):
+        """Callers that predate the split bill the whole bucket at 5 minutes."""
+        self.assertAlmostEqual(
+            calc_cost("claude-opus-4-6", 0, 0, 0, 1_000_000),
+            calc_cost("claude-opus-4-6", 0, 0, 0, 1_000_000, 0),
+            places=6,
+        )
+
+    def test_mixed_ttl_cache_writes(self):
+        """The 5-minute portion is the remainder after the 1-hour portion."""
+        # 600k at 1h (2x) + 400k at 5m (1.25x) on Opus input $5:
+        #   0.6 * 10.00 + 0.4 * 6.25 = 6.00 + 2.50 = 8.50
+        cost = calc_cost("claude-opus-4-6", 0, 0, 0, 1_000_000, 600_000)
+        self.assertAlmostEqual(cost, 8.50, places=6)
+
+    def test_1h_portion_cannot_exceed_total(self):
+        """A malformed breakdown must not inflate cost beyond the total."""
+        cost = calc_cost("claude-opus-4-6", 0, 0, 0, 1_000_000, 5_000_000)
+        self.assertAlmostEqual(cost, 10.00, places=6)
+
+    def test_negative_1h_portion_is_ignored(self):
+        cost = calc_cost("claude-opus-4-6", 0, 0, 0, 1_000_000, -5)
+        self.assertAlmostEqual(cost, 6.25, places=6)
+
     def test_unknown_model_costs_zero(self):
         cost = calc_cost("glm-5.1", 1_000_000, 500_000, 100_000, 50_000)
         self.assertEqual(cost, 0.0)


### PR DESCRIPTION
Fixes #162.

## What was wrong

Anthropic bills cache writes at **1.25x** base input for the 5-minute TTL and **2x** for the 1-hour TTL. `scanner.py` read only the aggregate `cache_creation_input_tokens`, and every cost path applied `cache_write` — the 5-minute rate — to the whole bucket. 1-hour writes were therefore billed 37.5% under their real rate.

Claude Code writes most of its cache with a 1-hour TTL, so this isn't a rounding error. The API returns the split alongside the aggregate:

```json
"usage": {
  "cache_creation_input_tokens": 3904,
  "cache_creation": {
    "ephemeral_5m_input_tokens": 0,
    "ephemeral_1h_input_tokens": 3904
  }
}
```

## Measured effect

Same 425-file corpus, `python cli.py scan && python cli.py stats`, before and after:

| | Est. total cost |
|---|---:|
| before | $3,379.26 |
| after | $3,702.44 |
| **difference** | **+$323.18 (9.6%)** |

(The issue quotes a larger percentage against raw cache-write cost across all records; this is the smaller, more relevant figure measured through the tool's own deduplicated pipeline.)

## Approach

The goal was to change pricing without disturbing token accounting or the two duplicated pricing tables.

- **`cache_creation_tokens` still holds the aggregate.** Only the 1-hour portion is new, in a `cache_creation_1h_tokens` column on `turns`. Every existing token total and display is untouched.
- **The 5-minute portion is derived as the remainder.** Rows recorded before this change have `1h = 0` and therefore bill exactly as they did — the migration needs no backfill and no rescan.
- **The 1-hour rate is derived as `2 x input`** rather than adding a `cache_write_1h` entry to both `PRICING` tables. Those tables are duplicated between `cli.py` and `dashboard.py` (#82), so deriving avoids adding a third place to keep in sync.
- **`calc_cost` / `calcCost` take an optional trailing argument.** Omitting it bills everything at the 5-minute rate, so any caller not updated here behaves as before.
- Existing databases migrate in place through the repo's own `_ensure_column` helper.

## Edge cases handled

- **Older logs with no `cache_creation` object** keep the whole bucket on the 5-minute rate.
- **A breakdown claiming more 1-hour tokens than the aggregate** is clamped to the aggregate, so a malformed record can't inflate cost. I saw 22 such records in ~41k; this also covers the case where `5m + 1h` doesn't reconcile.
- **Negative values** are clamped to zero.
- **Both parse paths** are covered — `scanner.py` has a second, more-indented assistant-record path for sidechain/subagent files that would otherwise have silently kept the old behaviour.

## Tests

`153 passed` (147 existing, unchanged, plus 6 new):

- 1-hour writes bill at 2x input
- 5-minute-only writes are unchanged at 1.25x
- omitting the new argument is backwards compatible
- mixed TTLs split correctly
- a 1-hour portion exceeding the total is clamped
- a negative 1-hour portion is ignored

## Note on the tables

`cache_write` remains the 5-minute rate in both tables and is untouched, so no existing entry changes meaning.
