### PR TITLE
fix: step past occupied ports and open a connectable URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Claude Code writes one JSONL file per session to `~/.claude/projects/`. Each lin
 
 `dashboard.py` serves a single-page dashboard on `localhost:8080` with Chart.js charts (loaded from CDN). It auto-refreshes every 30 seconds and supports model filtering and a date-range dropdown with bookmarkable URLs. A sticky section nav jumps between sections, and every chart/table can be collapsed (remembered across reloads). The bind address and port can be configured with the `--host` and `--port` flags, or the `HOST` and `PORT` environment variables (defaults: `localhost`, `8080`).
 
+If the port is already in use, the dashboard steps up to the next free one and prints which port it settled on. Port 8080 is a popular default, and a reverse proxy such as OrbStack or Docker Desktop holding it is easy to miss: those accept the connection and answer with nothing, so the browser reports `ERR_EMPTY_RESPONSE` rather than a connection refusal. The dashboard therefore checks whether a port answers before binding it, on both IPv4 and IPv6, since a plain bind can silently coexist with a wildcard one. For the same reason it opens `http://127.0.0.1:PORT` rather than `localhost`: on macOS `localhost` resolves to `::1` first, while the server listens on IPv4. Passing `--no-browser` pins the port instead: a supervising process (the VS Code extension) polls the exact port it asked for, so the server binds that port or exits.
+
 ---
 
 ## Cost estimates

--- a/cli.py
+++ b/cli.py
@@ -396,9 +396,8 @@ def cmd_stats():
 
 def cmd_dashboard(projects_dir=None, host=None, port=None, no_browser=False, surface=None):
     import threading
-    import time
 
-    from dashboard import serve
+    from dashboard import serve, browser_url
 
     host = host or os.environ.get("HOST", "localhost")
     port = int(port or os.environ.get("PORT", "8080"))
@@ -422,18 +421,23 @@ def cmd_dashboard(projects_dir=None, host=None, port=None, no_browser=False, sur
 
     threading.Thread(target=background_scan, daemon=True).start()
 
-    # Open a browser for users running this as a script (see README). The VS Code
-    # extension passes --no-browser since it embeds the dashboard in a webview.
-    if not no_browser:
-        import webbrowser
+    # Open a browser for users running this as a script (see README). The VS
+    # Code extension passes --no-browser since it embeds the dashboard in a
+    # webview. serve() calls this once the socket is listening and tells us the
+    # port it actually bound, which is not always the one we asked for -- no
+    # sleep to guess at readiness, no guess at the port either.
+    def on_ready(actual_port):
+        if not no_browser:
+            import webbrowser
 
-        def open_browser():
-            time.sleep(1.0)
-            webbrowser.open(f"http://{host}:{port}")
+            webbrowser.open(browser_url(host, actual_port))
 
-        threading.Thread(target=open_browser, daemon=True).start()
-
-    serve(host=host, port=port, surface=surface)
+    # Only the interactive path may drift to another port. Under --no-browser a
+    # supervisor picked this port, polls it for readiness, and keys the
+    # webview's localStorage on that origin (see vscode-extension/src/
+    # extension.ts) -- moving would read as a failed start.
+    serve(host=host, port=port, surface=surface,
+          fallback=not no_browser, on_ready=on_ready)
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────

--- a/dashboard.py
+++ b/dashboard.py
@@ -4,6 +4,7 @@ dashboard.py - Local web dashboard served on localhost:8080.
 
 import json
 import os
+import socket
 import sqlite3
 from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 from urllib.parse import urlparse
@@ -2293,19 +2294,108 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self.end_headers()
 
 
-def serve(host=None, port=None, surface=None):
+PORT_PROBE_TIMEOUT = 0.2
+PORT_ATTEMPTS = 10
+
+
+def port_is_taken(port, timeout=PORT_PROBE_TIMEOUT):
+    """True if anything already answers on `port`, over IPv4 or IPv6.
+
+    bind() cannot answer this question. TCPServer sets allow_reuse_address, so
+    on macOS/BSD a specific bind (127.0.0.1:8080) coexists happily with a
+    wildcard bind (*:8080) held by a reverse proxy such as OrbStack or Docker
+    Desktop -- no EADDRINUSE. The proxy still wins connections addressed to the
+    family it holds, and answers them with nothing, which a browser reports as
+    ERR_EMPTY_RESPONSE. Both families matter: `localhost` resolves to ::1 first
+    on macOS, so an IPv6-only squatter intercepts the browser even when the
+    IPv4 bind succeeded. Connecting is the only reliable probe.
+    """
+    for family, addr in ((socket.AF_INET, "127.0.0.1"), (socket.AF_INET6, "::1")):
+        try:
+            sock = socket.socket(family, socket.SOCK_STREAM)
+        except OSError:
+            continue  # host has no support for this family
+        sock.settimeout(timeout)
+        try:
+            sock.connect((addr, port))
+            return True
+        except OSError:
+            pass
+        finally:
+            sock.close()
+    return False
+
+
+def create_server(host, port, attempts=PORT_ATTEMPTS, probe=True):
+    """Bind a dashboard server, stepping past ports that are already in use.
+
+    Returns (server, actual_port). Set probe=False with attempts=1 to demand
+    one exact port and fail loudly -- that is what a supervising process (the
+    VS Code extension) needs, since it polls the port it asked for.
+    """
+    last_error = None
+    for candidate in range(port, port + attempts):
+        if probe and port_is_taken(candidate):
+            continue
+        try:
+            return ThreadingHTTPServer((host, candidate), DashboardHandler), candidate
+        except OSError as e:
+            last_error = e
+            continue
+    if attempts == 1:
+        # No range was searched, so don't describe one. This is the message a
+        # supervising process shows its user.
+        raise OSError(f"Port {port} is already in use.") from last_error
+    last = port + attempts - 1
+    raise OSError(
+        f"No free port available in range {port}-{last}. "
+        f"Free one up, or pass --port with a different starting point."
+    ) from last_error
+
+
+def browser_url(host, port):
+    """The address to hand a client for a server bound to `host`.
+
+    `host` is a bind address, which is not always somewhere you can connect to.
+    `0.0.0.0` and `::` are wildcards, not destinations. `localhost` is worse
+    than useless: getaddrinfo returns ::1 ahead of 127.0.0.1 on macOS while the
+    server binds IPv4 only, so it routes clients to whatever else holds the
+    IPv6 wildcard, or to nothing at all.
+    """
+    if host in ("localhost", "", "0.0.0.0"):
+        return f"http://127.0.0.1:{port}"
+    if host in ("::", "::0"):
+        return f"http://[::1]:{port}"
+    if ":" in host:  # IPv6 literal needs brackets in a URL
+        return f"http://[{host}]:{port}"
+    return f"http://{host}:{port}"
+
+
+def serve(host=None, port=None, surface=None, fallback=True, on_ready=None):
     global SURFACE
     if surface:
         SURFACE = surface
     host = host or os.environ.get("HOST", "localhost")
     port = port or int(os.environ.get("PORT", "8080"))
-    server = ThreadingHTTPServer((host, port), DashboardHandler)
-    print(f"Dashboard running at http://{host}:{port}")
+    if fallback:
+        server, actual_port = create_server(host, port)
+    else:
+        # A supervising process pinned this port; bind it or die, exactly as
+        # before. No probe -- a stale socket in TIME_WAIT must not turn a
+        # restart that bind() would have allowed into a spurious failure.
+        server, actual_port = create_server(host, port, attempts=1, probe=False)
+    if actual_port != port:
+        print(f"Port {port} is in use. Serving on {actual_port} instead.")
+    print(f"Dashboard running at {browser_url(host, actual_port)}")
     print("Press Ctrl+C to stop.")
     try:
+        if on_ready:
+            on_ready(actual_port)
         server.serve_forever()
     except KeyboardInterrupt:
         print("\nStopped.")
+    finally:
+        server.server_close()
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -215,5 +215,40 @@ class TestDashboardNoBrowser(unittest.TestCase):
             mock_serve.assert_called_once()
 
 
+class TestDashboardPortFallback(unittest.TestCase):
+    """Fallback belongs to the interactive path, not the supervised one."""
+
+    def test_cli_run_allows_fallback(self):
+        with mock.patch.object(cli, "cmd_scan"), \
+             mock.patch("dashboard.serve") as mock_serve, \
+             mock.patch("webbrowser.open"), \
+             redirect_stdout(io.StringIO()):
+            cli.cmd_dashboard(host="localhost", port=8080, no_browser=False)
+            self.assertTrue(mock_serve.call_args.kwargs["fallback"])
+
+    def test_no_browser_pins_the_port(self):
+        """The extension polls the exact port it passed (extension.ts:126) and
+        keys the webview's localStorage on that origin, so silently landing
+        elsewhere would read as a failed start."""
+        with mock.patch.object(cli, "cmd_scan"), \
+             mock.patch("dashboard.serve") as mock_serve, \
+             mock.patch("webbrowser.open"), \
+             redirect_stdout(io.StringIO()):
+            cli.cmd_dashboard(host="127.0.0.1", port=9999, no_browser=True)
+            self.assertFalse(mock_serve.call_args.kwargs["fallback"])
+
+    def test_browser_opens_the_port_actually_bound(self):
+        """serve() reports the bound port via on_ready; the browser must follow
+        it, not the port that was originally requested."""
+        with mock.patch.object(cli, "cmd_scan"), \
+             mock.patch("dashboard.serve") as mock_serve, \
+             mock.patch("webbrowser.open") as mock_open, \
+             redirect_stdout(io.StringIO()):
+            cli.cmd_dashboard(host="localhost", port=8080, no_browser=False)
+            on_ready = mock_serve.call_args.kwargs["on_ready"]
+            on_ready(8083)  # serve() landed here after stepping past squatters
+            mock_open.assert_called_once_with("http://127.0.0.1:8083")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,16 +1,22 @@
 """Tests for dashboard.py - API endpoint and data retrieval."""
 
+import io
 import json
 import os
+import socket
 import sqlite3
 import tempfile
 import threading
 import unittest
 import urllib.request
+from contextlib import redirect_stdout
 from pathlib import Path
 
 from scanner import get_db, init_db, upsert_sessions, insert_turns
-from dashboard import get_dashboard_data, DashboardHandler, HTML_TEMPLATE
+from dashboard import (
+    get_dashboard_data, DashboardHandler, HTML_TEMPLATE,
+    port_is_taken, create_server, browser_url, serve,
+)
 
 try:
     from http.server import HTTPServer
@@ -492,6 +498,212 @@ class TestPricingParity(unittest.TestCase):
                 CLI_PRICING[model]["output"], js_prices[model]["output"],
                 msg=f"{model} output price mismatch"
             )
+
+
+def _free_port():
+    """Ask the OS for an unused port, then release it."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class _Squatter:
+    """A listener that accepts connections on `port` and answers nothing.
+
+    Mimics a reverse proxy (OrbStack, Docker Desktop) holding a port: the TCP
+    handshake succeeds, so a browser gets ERR_EMPTY_RESPONSE rather than a
+    connection refusal.
+    """
+
+    def __init__(self, port, family=socket.AF_INET, v6only=True, addr=None):
+        self.sock = socket.socket(family, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        if family == socket.AF_INET6:
+            self.sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY,
+                                 1 if v6only else 0)
+        # Defaults to a wildcard bind, which is the interesting case: it
+        # coexists with a later bind to a specific address instead of raising
+        # EADDRINUSE. Pass addr to squat one specific address and block a bind.
+        if addr is None:
+            addr = "::" if family == socket.AF_INET6 else ""
+        self.sock.bind((addr, port))
+        self.sock.listen(5)
+
+    def close(self):
+        self.sock.close()
+
+
+class TestPortIsTaken(unittest.TestCase):
+    def test_free_port_is_not_taken(self):
+        self.assertFalse(port_is_taken(_free_port()))
+
+    def test_ipv4_listener_makes_port_taken(self):
+        port = _free_port()
+        squatter = _Squatter(port, socket.AF_INET)
+        self.addCleanup(squatter.close)
+        self.assertTrue(port_is_taken(port))
+
+    def test_ipv6_only_listener_makes_port_taken(self):
+        """The OrbStack case: nothing on IPv4, a squatter on IPv6.
+
+        `localhost` resolves to ::1 first on macOS, so the browser lands on the
+        squatter even though an IPv4 bind would have succeeded. Probing IPv4
+        alone would report the port as free and miss this entirely.
+        """
+        port = _free_port()
+        try:
+            squatter = _Squatter(port, socket.AF_INET6, v6only=True)
+        except OSError as e:  # pragma: no cover - host without IPv6 loopback
+            self.skipTest(f"no IPv6 loopback available: {e}")
+        self.addCleanup(squatter.close)
+        self.assertTrue(port_is_taken(port))
+
+
+class TestCreateServer(unittest.TestCase):
+    def test_uses_requested_port_when_free(self):
+        port = _free_port()
+        server, actual = create_server("127.0.0.1", port)
+        self.addCleanup(server.server_close)
+        self.assertEqual(actual, port)
+        self.assertEqual(server.socket.getsockname()[1], port)
+
+    def test_falls_back_past_an_ipv4_squatter(self):
+        port = _free_port()
+        squatter = _Squatter(port, socket.AF_INET)
+        self.addCleanup(squatter.close)
+        server, actual = create_server("127.0.0.1", port)
+        self.addCleanup(server.server_close)
+        self.assertNotEqual(actual, port)
+        self.assertGreater(actual, port)
+
+    def test_falls_back_past_an_ipv6_only_squatter(self):
+        """Regression guard for the ERR_EMPTY_RESPONSE bug.
+
+        A bare `ThreadingHTTPServer(("localhost", port))` binds IPv4 happily
+        here -- no EADDRINUSE -- so any fallback keyed on bind failure would
+        keep the port and leave the browser talking to the squatter.
+        """
+        port = _free_port()
+        try:
+            squatter = _Squatter(port, socket.AF_INET6, v6only=True)
+        except OSError as e:  # pragma: no cover - host without IPv6 loopback
+            self.skipTest(f"no IPv6 loopback available: {e}")
+        self.addCleanup(squatter.close)
+        server, actual = create_server("127.0.0.1", port)
+        self.addCleanup(server.server_close)
+        self.assertNotEqual(actual, port)
+
+    def test_raises_when_every_candidate_is_taken(self):
+        port = _free_port()
+        squatters = []
+        for offset in range(3):
+            try:
+                s = _Squatter(port + offset, socket.AF_INET)
+            except OSError:  # pragma: no cover - neighbouring port already used
+                self.skipTest("could not reserve a contiguous port range")
+            squatters.append(s)
+            self.addCleanup(s.close)
+        with self.assertRaises(OSError) as ctx:
+            create_server("127.0.0.1", port, attempts=3)
+        self.assertIn(str(port), str(ctx.exception))
+
+    def test_attempts_bounds_the_search(self):
+        port = _free_port()
+        squatter = _Squatter(port, socket.AF_INET)
+        self.addCleanup(squatter.close)
+        with self.assertRaises(OSError):
+            create_server("127.0.0.1", port, attempts=1)
+
+    def test_single_candidate_failure_names_that_port_plainly(self):
+        """With no range to search, "no free port in range N-N" is noise.
+
+        The VS Code extension surfaces this text in its output channel, so it
+        should read as plainly as the OSError it replaced.
+        """
+        port = _free_port()
+        squatter = _Squatter(port, socket.AF_INET, addr="127.0.0.1")
+        self.addCleanup(squatter.close)
+        with self.assertRaises(OSError) as ctx:
+            create_server("127.0.0.1", port, attempts=1, probe=False)
+        message = str(ctx.exception)
+        self.assertIn(str(port), message)
+        self.assertIn("in use", message)
+        self.assertNotIn("range", message)
+
+
+class TestBrowserUrl(unittest.TestCase):
+    """A bind address is not always an address you can connect to."""
+
+    def test_localhost_becomes_ipv4_literal(self):
+        """getaddrinfo puts ::1 first on macOS, but the server binds IPv4 only,
+        so `localhost` can route a client away from the server entirely."""
+        self.assertEqual(browser_url("localhost", 8081), "http://127.0.0.1:8081")
+
+    def test_wildcard_bind_becomes_ipv4_literal(self):
+        self.assertEqual(browser_url("0.0.0.0", 8081), "http://127.0.0.1:8081")
+
+    def test_ipv6_wildcard_becomes_loopback_literal(self):
+        self.assertEqual(browser_url("::", 8081), "http://[::1]:8081")
+
+    def test_ipv6_literal_gets_brackets(self):
+        self.assertEqual(browser_url("::1", 8081), "http://[::1]:8081")
+
+    def test_explicit_host_is_left_alone(self):
+        self.assertEqual(browser_url("192.168.1.5", 8081), "http://192.168.1.5:8081")
+
+
+class TestServeAnnouncement(unittest.TestCase):
+    @staticmethod
+    def _stop_immediately(_actual_port):
+        raise KeyboardInterrupt
+
+    def _serve_output(self, host, port):
+        out = io.StringIO()
+        with redirect_stdout(out):
+            serve(host=host, port=port, on_ready=self._stop_immediately)
+        return out.getvalue()
+
+    def test_warns_before_announcing_a_moved_port(self):
+        """The explanation has to precede the conclusion it explains.
+
+        Announcing the URL first and only then mentioning the move reads as if
+        two unrelated things happened.
+        """
+        port = _free_port()
+        squatter = _Squatter(port, socket.AF_INET)
+        self.addCleanup(squatter.close)
+
+        printed = self._serve_output("localhost", port)
+
+        self.assertIn(str(port), printed)
+        self.assertIn("in use", printed)
+        self.assertLess(printed.index("in use"), printed.index("Dashboard running"))
+
+    def test_no_warning_when_the_requested_port_was_available(self):
+        printed = self._serve_output("localhost", _free_port())
+        self.assertNotIn("in use", printed)
+
+    def test_announced_url_is_connectable(self):
+        """The line printed to the terminal gets copy-pasted into a browser.
+
+        Printing the raw bind address sends the user to http://localhost:PORT,
+        which resolves to ::1 and misses the IPv4-only server -- the very
+        failure the port fallback just stepped around.
+        """
+        port = _free_port()
+
+        def stop_immediately(_actual_port):
+            raise KeyboardInterrupt
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            serve(host="localhost", port=port, on_ready=stop_immediately)
+
+        printed = out.getvalue()
+        self.assertIn(f"http://127.0.0.1:{port}", printed)
+        self.assertNotIn("localhost", printed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`python cli.py dashboard` can start successfully and still be unreachable, showing `ERR_EMPTY_RESPONSE` in the browser. Two independent causes, neither visible from that error.

**A reverse proxy holding the port.** OrbStack and Docker Desktop bind `*:8080` as a wildcard. `TCPServer` sets `allow_reuse_address`, so on macOS/BSD a later bind to `127.0.0.1:8080` **succeeds and coexists** with it rather than raising `EADDRINUSE`. The proxy still wins connections on the address family it holds and answers them with nothing, which the browser reports as `ERR_EMPTY_RESPONSE`. Worth stressing: because `bind()` never fails here, a port fallback keyed on `EADDRINUSE` would never fire.

**Handing the browser a bind address.** `serve()` printed and opened `http://localhost:PORT`, but `getaddrinfo` returns `::1` ahead of `127.0.0.1` on macOS while `ThreadingHTTPServer` defaults to `AF_INET` and listens on IPv4 only. The browser follows `::1`, misses the server, and lands on whatever holds the IPv6 wildcard, or on nothing.

Measured on macOS 15 with OrbStack running:

```
getaddrinfo('localhost', 8080) order:
   AF_INET6 ('::1', 8080)          <- browser takes this
   AF_INET  ('127.0.0.1', 8080)

[IPv4 127.0.0.1] 120 bytes -> b'HTTP/1.0 200 OK\r\nServer: BaseHTTP/0.6 ...'
[IPv6 ::1      ]   0 bytes -> b''      <- ERR_EMPTY_RESPONSE
```

## Change

- `port_is_taken()` probes a port by connecting to it, **on both address families**, since `bind()` cannot answer the question.
- `create_server()` steps up to the next free port (10 candidates) and returns the port it actually bound.
- `browser_url()` maps a bind address to something connectable. Both the printed line and the opened URL go through it, so copy-pasting from the terminal works too.
- Fallback is limited to the interactive path. Under `--no-browser` the port is pinned and the server binds it or exits.
- Removes the `sleep(1.0)` the browser thread used to guess at readiness: `serve()` reports the bound port through an `on_ready` callback once the socket is listening.

## VS Code extension is unaffected

`extension.ts:121` picks the port via `resolveStablePort`, `:126` polls that exact port for readiness, and the webview's `localStorage` is keyed on that origin, so silent drift would read as a failed start. The extension always passes `--no-browser`, which pins the port. No TypeScript changes; `server-manager.ts:75` already documents that callers handle port-collision recovery at a higher level.

Verified by simulating the extension's spawn contract:

| scenario | result |
|---|---|
| `--no-browser --port <free>` | binds the requested port, `/api/data` returns 200 |
| `--no-browser --port <taken>` | exits 1 with `Port N is already in use.`, never moves |

## Tests

167 pass. The headline regression test reproduces the bug exactly: with an **IPv6-only** squatter, a bare `ThreadingHTTPServer` bind succeeds, so any fallback keyed on bind failure keeps the port and leaves the browser talking to the squatter.

End-to-end with OrbStack on 8080:

```
Port 8080 is in use. Serving on 8081 instead.
Dashboard running at http://127.0.0.1:8081
```

Note: the suite emits a pre-existing `ResourceWarning: unclosed socket`. It reproduces on unmodified `main`, so it is untouched here.