### PR TITLE
Auto-fallback port + login/boot autostart for docker dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.5.6 — TBD
+
+### Project / docs
+
+- `scripts/run-docker.sh` now auto-falls-back to the next free port when its default (9898) is taken, instead of failing the `docker run` with a bind error.
+- Added `scripts/install-autostart.sh` to run the dashboard container automatically at login/boot (macOS LaunchAgent, Linux systemd user unit).
+
 ## v1.5.5 — 2026-07-10
 
 ### Dashboard

--- a/scripts/install-autostart.sh
+++ b/scripts/install-autostart.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Installs a login/boot service that runs run-docker.sh, so the claude-usage
+# container comes up automatically and picks a free port if 9898 is taken.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+RUN_SCRIPT="$REPO_DIR/scripts/run-docker.sh"
+LABEL="com.claude-usage.dashboard"
+
+case "$(uname -s)" in
+  Darwin)
+    PLIST_DIR="$HOME/Library/LaunchAgents"
+    PLIST="$PLIST_DIR/${LABEL}.plist"
+    LOG_DIR="$HOME/Library/Logs/claude-usage"
+    mkdir -p "$PLIST_DIR" "$LOG_DIR"
+
+    cat > "$PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>${RUN_SCRIPT}</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>StandardOutPath</key><string>${LOG_DIR}/stdout.log</string>
+  <key>StandardErrorPath</key><string>${LOG_DIR}/stderr.log</string>
+</dict>
+</plist>
+EOF
+
+    launchctl unload "$PLIST" 2>/dev/null || true
+    launchctl load "$PLIST"
+    echo "✅  Installed LaunchAgent: $PLIST"
+    echo "    Logs: $LOG_DIR"
+    ;;
+
+  Linux)
+    UNIT_DIR="$HOME/.config/systemd/user"
+    UNIT="$UNIT_DIR/${LABEL}.service"
+    mkdir -p "$UNIT_DIR"
+
+    cat > "$UNIT" <<EOF
+[Unit]
+Description=claude-usage dashboard container
+After=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash ${RUN_SCRIPT}
+RemainAfterExit=yes
+
+[Install]
+WantedBy=default.target
+EOF
+
+    systemctl --user daemon-reload
+    systemctl --user enable --now "${LABEL}.service"
+    echo "✅  Installed systemd user unit: $UNIT"
+    echo "    Enable lingering to start at boot without login: sudo loginctl enable-linger $USER"
+    ;;
+
+  *)
+    echo "Unsupported OS: $(uname -s)" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -1,17 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:$PATH"
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 IMAGE="claude-usage"
 CONTAINER="claude-usage"
 NETWORK="claude-usage-net"
-PORT=9898
+PORT="${PORT:-9898}"
+
+port_in_use() {
+  # Port is "in use" only if held by something other than our own container.
+  if command -v lsof &>/dev/null; then
+    lsof -iTCP:"$1" -sTCP:LISTEN -n -P &>/dev/null
+  else
+    (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && { exec 3>&-; return 0; } || return 1
+  fi
+}
 
 echo "▶  Checking for running container..."
 if docker ps -q --filter "name=^${CONTAINER}$" | grep -q .; then
   echo "⏹  Stopping ${CONTAINER}..."
   docker stop "$CONTAINER"
 fi
+
+while port_in_use "$PORT"; do
+  echo "⚠  Port ${PORT} in use, trying $((PORT + 1))..."
+  PORT=$((PORT + 1))
+done
 
 echo "🔗  Ensuring isolated network..."
 if ! docker network inspect "$NETWORK" &>/dev/null; then

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -17,10 +17,10 @@ port_in_use() {
   fi
 }
 
-echo "▶  Checking for running container..."
-if docker ps -q --filter "name=^${CONTAINER}$" | grep -q .; then
-  echo "⏹  Stopping ${CONTAINER}..."
-  docker stop "$CONTAINER"
+echo "▶  Checking for existing container..."
+if docker ps -aq --filter "name=^${CONTAINER}$" | grep -q .; then
+  echo "⏹  Removing existing ${CONTAINER}..."
+  docker rm -f "$CONTAINER"
 fi
 
 while port_in_use "$PORT"; do
@@ -43,7 +43,8 @@ echo "🔨  Building image..."
 docker build -t "$IMAGE" .
 
 echo "🚀  Starting container..."
-docker run --rm -d \
+docker run -d \
+  --restart unless-stopped \
   --name "$CONTAINER" \
   --network "$NETWORK" \
   -p "$PORT:8080" \


### PR DESCRIPTION
## Summary
- `scripts/run-docker.sh` now checks if its default port (9898) is already bound and walks to the next free one instead of failing the `docker run` with a bind error.
- Added `scripts/install-autostart.sh` to run the dashboard container automatically at login/boot — installs a macOS LaunchAgent or a Linux systemd user unit that invokes `run-docker.sh`.
- Bumped CHANGELOG with a `v1.5.6 — TBD` heading under "Project / docs".

## Test plan
- [x] Ran `scripts/run-docker.sh` manually with port 9898 occupied by another process — confirmed it fell through to 9899.
- [x] Ran `scripts/install-autostart.sh` on macOS — LaunchAgent loads, container starts on login, verified `docker ps` shows `claude-usage` running and reachable at `http://localhost:<port>`.
- [ ] Linux systemd path not tested on this pass (macOS-only dev machine) — logic mirrors the launchd path and uses portable `bash`/`lsof`/`/dev/tcp` fallback.
