### PR TITLE
fix(dashboard): let the hourly chart's hour labels rotate instead of overlapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.5.6 — TBD
+
+### Dashboard
+
+- Fixed the **hour labels on the Average Hourly Distribution chart overlapping into an unreadable smear** on narrower windows. The x axis was pinned to `maxRotation: 0` with `autoSkip: false`, so Chart.js could neither tilt the labels nor drop any — it just crammed all 24 `HH:00` ticks into whatever width was available. The axis now allows rotation up to 90°, so the labels stay horizontal when there's room and tilt progressively as the chart narrows, matching the Daily Token Usage chart's behaviour. All 24 hours remain visible at every width.
+
 ## v1.5.5 — 2026-07-10
 
 ### Dashboard

--- a/dashboard.py
+++ b/dashboard.py
@@ -1433,7 +1433,7 @@ function renderHourlyChart(agg) {
         },
       },
       scales: {
-        x: { ticks: { color: C.axis, maxRotation: 0, autoSkip: false, font: { size: 10 } }, grid: { color: C.border } },
+        x: { ticks: { color: C.axis, minRotation: 0, maxRotation: 90, autoSkip: false, font: { size: 10 } }, grid: { color: C.border } },
         y:  { position: 'left',  beginAtZero: true, ticks: { color: C.axis, callback: v => v.toFixed(1) },     grid: { color: C.border }, title: { display: true, text: 'Avg turns / hour',         color: C.axis, font: { size: 11 } } },
         y1: { position: 'right', beginAtZero: true, ticks: { color: C.axis, callback: v => fmt(v) }, grid: { drawOnChartArea: false },   title: { display: true, text: 'Avg output tokens / hour', color: C.axis, font: { size: 11 } } },
       }


### PR DESCRIPTION
## The problem

On the **Average Hourly Distribution** chart, the hour labels collapse into an unreadable smear once the window is narrower than roughly 1000px:

`00:0001:0002:0003:00…` — 24 ticks fighting for space that fits maybe half of them.

The cause is in the x-axis config ([`dashboard.py`](https://github.com/phuryn/claude-usage/blob/DEV/dashboard.py), `renderHourlyChart`):

```js
x: { ticks: { color: C.axis, maxRotation: 0, autoSkip: false, font: { size: 10 } }, ... }
```

`maxRotation: 0` forbids tilting and `autoSkip: false` forbids dropping ticks, so Chart.js has no escape hatch left — it draws all 24 `HH:00` labels at whatever width is available and lets them overlap. On a wide monitor there's enough room that nothing looks wrong, which is presumably why it went unnoticed.

## The fix

One line — allow rotation, keep every hour labelled:

```js
x: { ticks: { color: C.axis, minRotation: 0, maxRotation: 90, autoSkip: false, font: { size: 10 } }, ... }
```

Chart.js now picks the smallest angle that avoids collisions, so nothing changes on wide screens and the labels tilt progressively as the chart narrows. `autoSkip: false` is kept deliberately: for an hour-of-day axis, hiding every other hour is worse than tilting.

This also brings the chart in line with the **Daily Token Usage** chart directly above it, which already rotates its date labels — so the two axes no longer disagree about how to handle crowding.

## Verification

Headless Chrome against a live dashboard, at two widths:

| Viewport | Result |
| --- | --- |
| 900px (where the overlap was reported) | labels tilt to ~45°, all 24 readable |
| 560px (narrow panel / mobile) | labels tilt further, ~65°, still no overlap |
| wide | unchanged — horizontal, as before |

`python -m unittest discover -s tests` → 147 tests, OK.

## Note on the CHANGELOG

The bullet lands under `## v1.5.6 — TBD`, which #161 also opens. If #161 merges first this will conflict on that heading — trivial to resolve, and happy to rebase on request.
