### PR TITLE
fix(scanner): name background subagent dispatches instead of 'unknown'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.5.6 — TBD
+
+### Scanner
+
+- Named subagent dispatches that previously showed as **unknown** in *Top Subagent Dispatches* and the subagent breakdown. The scanner learned an agent's name only from the parent's closing `toolUseResult`, which carries `agentType` only when the dispatch ran **synchronously and completed**; a background (`isAsync`) dispatch logs `status: "async_launched"` with no `agentType`, so every one of them was unnamed. The subagent's own transcript records carry `attributionAgent` alongside `agentId`, so the name is now read from there as well — independent of how the dispatch was launched or whether it finished. A parent-supplied `agentType` still wins where present; attribution only fills gaps.
+- Added a one-time backfill (`agent_type_backfill_done` in `schema_meta`, mirroring the existing topic backfill) so existing databases pick up the names without a full rescan — already-processed transcripts are re-read for `attributionAgent` records only, leaving `turns` untouched so token totals cannot drift.
+
 ## v1.5.5 — 2026-07-10
 
 ### Dashboard

--- a/scanner.py
+++ b/scanner.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 # runtime version has to live here as a constant. Keep this in lockstep with the
 # top CHANGELOG heading and vscode-extension/package.json (a parity test guards
 # all three; see tests/test_version.py).
-VERSION = "1.5.5"
+VERSION = "1.5.6"
 
 PROJECTS_DIR = Path.home() / ".claude" / "projects"
 XCODE_PROJECTS_DIR = Path.home() / "Library" / "Developer" / "Xcode" / "CodingAssistant" / "ClaudeAgentConfig" / "projects"
@@ -221,6 +221,50 @@ def _backfill_topics(conn, jsonl_files):
     return len(titles)
 
 
+def _backfill_agent_types(conn, jsonl_files):
+    """One-time backfill of subagent names for a DB scanned before attribution.
+
+    Same shape as _backfill_topics: files already in processed_files are skipped
+    by an incremental scan, so their ``attributionAgent`` records are never seen
+    and those agents keep rendering as 'unknown'. Re-read just those records
+    (turns are left untouched, so token totals cannot drift) and name any agent
+    that has no name yet — including agents with no ``agents`` row at all, which
+    is the usual case for background dispatches. Runs once, gated by a flag in
+    schema_meta (see scan()). Returns the number of agents named.
+    """
+    named = {r["agent_id"] for r in conn.execute(
+        "SELECT agent_id FROM agents WHERE agent_type IS NOT NULL AND agent_type != ''")}
+
+    found = {}  # agent_id -> agent_type
+    for filepath in jsonl_files:
+        try:
+            with open(filepath, encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    # Cheap prefilter: skip JSON-parsing lines that cannot match.
+                    if "attributionAgent" not in line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    attribution = extract_agent_attribution(record)
+                    if attribution is None:
+                        continue
+                    if attribution["agent_id"] in named:
+                        continue
+                    found.setdefault(attribution["agent_id"], attribution["agent_type"])
+        except Exception as e:
+            print(f"  Warning: error reading {filepath}: {e}")
+
+    if found:
+        upsert_agents(conn, [
+            {"source": "attribution", "agent_id": aid, "agent_type": atype}
+            for aid, atype in found.items()
+        ])
+        conn.commit()
+    return len(found)
+
+
 def project_name_from_cwd(cwd):
     """Derive a friendly project name from cwd path."""
     if not cwd:
@@ -278,6 +322,7 @@ def extract_agent_dispatch(record):
     if not agent_id or not agent_type:
         return None
     return {
+        "source": "dispatch",
         "agent_id": agent_id,
         "agent_type": agent_type,
         "dispatched_in_session": record.get("sessionId"),
@@ -289,29 +334,76 @@ def extract_agent_dispatch(record):
     }
 
 
+def extract_agent_attribution(record):
+    """Pull the subagent's name off one of its *own* transcript records.
+
+    ``extract_agent_dispatch`` reads the parent's closing ``toolUseResult``,
+    which only carries ``agentType`` when the dispatch ran synchronously and
+    completed. A background dispatch (``isAsync``) logs a launch record with
+    ``status: 'async_launched'`` and no ``agentType`` at all, so those agents
+    end up with no row in ``agents`` and render as 'unknown'.
+
+    Every assistant record inside the subagent's own jsonl carries
+    ``attributionAgent`` (the same human-readable name: 'general-purpose',
+    'Explore', a plugin agent like 'health:coach') alongside ``agentId``, so
+    the name is recoverable regardless of how the dispatch was launched or
+    whether it ever finished. This yields a name-only record; the parent's
+    dispatch record remains the source for stats and status.
+    """
+    agent_type = record.get("attributionAgent")
+    if not agent_type:
+        return None
+    agent_id = record_agent_id(record)
+    if not agent_id:
+        return None
+    return {"source": "attribution", "agent_id": agent_id, "agent_type": agent_type}
+
+
 def upsert_agents(conn, agents):
-    """Insert or update agent dispatch metadata. Last write wins per agent_id."""
+    """Insert or update agent metadata, routed by each record's ``source``.
+
+    Full dispatch records (from the parent's ``toolUseResult``) overwrite every
+    column — last write wins per agent_id, as before. Attribution records carry
+    a name only, and never clobber a name already learned from a dispatch.
+    Dispatches are applied first so that ordering is independent of the order
+    files happen to be scanned in.
+    """
     if not agents:
         return
-    conn.executemany("""
-        INSERT INTO agents
-            (agent_id, agent_type, dispatched_in_session, completed_at,
-             status, total_tokens, total_duration_ms, tool_use_count)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(agent_id) DO UPDATE SET
-            agent_type            = excluded.agent_type,
-            dispatched_in_session = excluded.dispatched_in_session,
-            completed_at          = excluded.completed_at,
-            status                = excluded.status,
-            total_tokens          = excluded.total_tokens,
-            total_duration_ms     = excluded.total_duration_ms,
-            tool_use_count        = excluded.tool_use_count
-    """, [
-        (a["agent_id"], a["agent_type"], a.get("dispatched_in_session"),
-         a.get("completed_at"), a.get("status"),
-         a.get("total_tokens"), a.get("total_duration_ms"), a.get("tool_use_count"))
-        for a in agents
-    ])
+
+    dispatches = [a for a in agents if a.get("source", "dispatch") != "attribution"]
+    attributions = [a for a in agents if a.get("source") == "attribution"]
+
+    if dispatches:
+        conn.executemany("""
+            INSERT INTO agents
+                (agent_id, agent_type, dispatched_in_session, completed_at,
+                 status, total_tokens, total_duration_ms, tool_use_count)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(agent_id) DO UPDATE SET
+                agent_type            = excluded.agent_type,
+                dispatched_in_session = excluded.dispatched_in_session,
+                completed_at          = excluded.completed_at,
+                status                = excluded.status,
+                total_tokens          = excluded.total_tokens,
+                total_duration_ms     = excluded.total_duration_ms,
+                tool_use_count        = excluded.tool_use_count
+        """, [
+            (a["agent_id"], a["agent_type"], a.get("dispatched_in_session"),
+             a.get("completed_at"), a.get("status"),
+             a.get("total_tokens"), a.get("total_duration_ms"), a.get("tool_use_count"))
+            for a in dispatches
+        ])
+
+    if attributions:
+        # COALESCE(NULLIF(...)) keeps an existing dispatch-derived name; it only
+        # fills a row that has none (or that this statement just created).
+        conn.executemany("""
+            INSERT INTO agents (agent_id, agent_type)
+            VALUES (?, ?)
+            ON CONFLICT(agent_id) DO UPDATE SET
+                agent_type = COALESCE(NULLIF(agents.agent_type, ''), excluded.agent_type)
+        """, [(a["agent_id"], a["agent_type"]) for a in attributions])
 
 
 def parse_jsonl_file(filepath):
@@ -371,6 +463,10 @@ def parse_jsonl_file(filepath):
                     dispatch = extract_agent_dispatch(record)
                     if dispatch is not None:
                         agents[dispatch["agent_id"]] = dispatch
+
+                attribution = extract_agent_attribution(record)
+                if attribution is not None:
+                    agents.setdefault(attribution["agent_id"], attribution)
 
                 timestamp = record.get("timestamp", "")
                 cwd = record.get("cwd", "")
@@ -606,6 +702,16 @@ def scan(projects_dir=None, projects_dirs=None, db_path=DB_PATH, verbose=True):
         if verbose and filled:
             print(f"Backfilled topic for {filled} existing session(s).")
 
+    # Same for subagent names: DBs scanned before attributionAgent was read have
+    # unnamed agents (shown as 'unknown') that an incremental scan would never
+    # revisit. No-ops on a fresh DB, where the agents table is still empty.
+    if _meta_get(conn, "agent_type_backfill_done") != "1":
+        named = _backfill_agent_types(conn, jsonl_files)
+        _meta_set(conn, "agent_type_backfill_done", "1")
+        conn.commit()
+        if verbose and named:
+            print(f"Backfilled name for {named} existing subagent dispatch(es).")
+
     new_files = 0
     updated_files = 0
     skipped_files = 0
@@ -700,6 +806,10 @@ def scan(projects_dir=None, projects_dirs=None, db_path=DB_PATH, verbose=True):
                             dispatch = extract_agent_dispatch(record)
                             if dispatch is not None:
                                 agents[dispatch["agent_id"]] = dispatch
+
+                        attribution = extract_agent_attribution(record)
+                        if attribution is not None:
+                            agents.setdefault(attribution["agent_id"], attribution)
 
                         timestamp = record.get("timestamp", "")
                         cwd = record.get("cwd", "")

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -7,7 +7,9 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scanner import get_db, init_db, parse_jsonl_file, scan
+from scanner import (
+    get_db, init_db, parse_jsonl_file, scan, extract_agent_attribution,
+)
 
 NL = chr(10)  # avoid backslash-escaped newline literals in source
 
@@ -166,6 +168,135 @@ class TestSubagentScanIntegration(unittest.TestCase):
         tables = {r["name"] for r in conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table'")}
         self.assertIn("agents", tables)
+        conn.close()
+
+
+def _async_dispatch(session_id="s1", agent_id="agent-1",
+                    timestamp="2026-04-08T10:01:00Z"):
+    """A background (isAsync) dispatch launch record: agentId but no agentType."""
+    return json.dumps({
+        "type": "user",
+        "sessionId": session_id,
+        "timestamp": timestamp,
+        "toolUseResult": {
+            "agentId": agent_id,
+            "isAsync": True,
+            "status": "async_launched",
+            "description": "Do the thing",
+            "resolvedModel": "claude-sonnet-5",
+        },
+    })
+
+
+class TestAgentAttribution(unittest.TestCase):
+    """attributionAgent on the subagent's own records names it (issue: 'unknown')."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def _write(self, relpath, lines):
+        path = os.path.join(self.tmpdir, relpath)
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        with open(path, "w") as f:
+            f.write(NL.join(lines) + NL)
+        return path
+
+    def test_extract_reads_name_and_id(self):
+        rec = {"type": "assistant", "agentId": "agent-x",
+               "attributionAgent": "Explore"}
+        self.assertEqual(extract_agent_attribution(rec),
+                         {"source": "attribution", "agent_id": "agent-x",
+                          "agent_type": "Explore"})
+
+    def test_extract_requires_both_fields(self):
+        self.assertIsNone(extract_agent_attribution({"agentId": "agent-x"}))
+        self.assertIsNone(extract_agent_attribution({"attributionAgent": "Explore"}))
+
+    def test_parse_captures_attribution(self):
+        path = self._write(os.path.join("proj", "subagents", "agent-1.jsonl"), [
+            _assistant(extra={"agentId": "agent-1", "attributionAgent": "herald"}),
+        ])
+        _, _, agents, _ = parse_jsonl_file(path)
+        self.assertEqual(len(agents), 1)
+        self.assertEqual(agents[0]["agent_id"], "agent-1")
+        self.assertEqual(agents[0]["agent_type"], "herald")
+        self.assertEqual(agents[0]["source"], "attribution")
+
+    def test_dispatch_name_wins_over_attribution(self):
+        """A parent-supplied agentType is authoritative and is never clobbered."""
+        projects = Path(self.tmpdir) / "projects"
+        parent = projects / "user" / "proj"
+        parent.mkdir(parents=True)
+        with open(parent / "sess-1.jsonl", "w") as f:
+            f.write(_dispatch(session_id="sess-1", agent_id="agent-1",
+                              agent_type="Explore") + NL)
+        sub = parent / "subagents"
+        sub.mkdir()
+        with open(sub / "agent-1.jsonl", "w") as f:
+            f.write(_assistant(session_id="sess-1", message_id="m-sub",
+                               extra={"agentId": "agent-1",
+                                      "attributionAgent": "something-else"}) + NL)
+
+        db = Path(self.tmpdir) / "usage.db"
+        scan(projects_dir=projects, db_path=db, verbose=False)
+        conn = sqlite3.connect(db)
+        self.assertEqual(
+            conn.execute("SELECT agent_type FROM agents WHERE agent_id='agent-1'")
+                .fetchone()[0], "Explore")
+        conn.close()
+
+    def test_async_dispatch_is_named_from_attribution(self):
+        """The real-world 'unknown' case: background dispatch, no agentType."""
+        projects = Path(self.tmpdir) / "projects"
+        parent = projects / "user" / "proj"
+        parent.mkdir(parents=True)
+        with open(parent / "sess-1.jsonl", "w") as f:
+            f.write(_async_dispatch(session_id="sess-1", agent_id="agent-9") + NL)
+        sub = parent / "subagents"
+        sub.mkdir()
+        with open(sub / "agent-9.jsonl", "w") as f:
+            f.write(_assistant(session_id="sess-1", message_id="m-sub",
+                               input_tokens=300,
+                               extra={"agentId": "agent-9",
+                                      "attributionAgent": "general-purpose"}) + NL)
+
+        db = Path(self.tmpdir) / "usage.db"
+        scan(projects_dir=projects, db_path=db, verbose=False)
+        conn = sqlite3.connect(db)
+        self.assertEqual(
+            conn.execute("SELECT agent_type FROM agents WHERE agent_id='agent-9'")
+                .fetchone()[0], "general-purpose")
+        conn.close()
+
+    def test_backfill_names_agents_in_already_scanned_db(self):
+        """Files already in processed_files are skipped; the backfill covers them."""
+        projects = Path(self.tmpdir) / "projects"
+        parent = projects / "user" / "proj"
+        parent.mkdir(parents=True)
+        sub = parent / "subagents"
+        sub.mkdir(parents=True)
+        with open(sub / "agent-7.jsonl", "w") as f:
+            f.write(_assistant(session_id="sess-1", message_id="m-sub",
+                               extra={"agentId": "agent-7",
+                                      "attributionAgent": "archivist"}) + NL)
+
+        db = Path(self.tmpdir) / "usage.db"
+        scan(projects_dir=projects, db_path=db, verbose=False)
+
+        # Simulate a DB produced before attribution existed: drop the name and
+        # the backfill marker, leaving processed_files intact.
+        conn = sqlite3.connect(db)
+        conn.execute("DELETE FROM agents")
+        conn.execute("DELETE FROM schema_meta WHERE key='agent_type_backfill_done'")
+        conn.commit()
+        conn.close()
+
+        scan(projects_dir=projects, db_path=db, verbose=False)
+
+        conn = sqlite3.connect(db)
+        self.assertEqual(
+            conn.execute("SELECT agent_type FROM agents WHERE agent_id='agent-7'")
+                .fetchone()[0], "archivist")
         conn.close()
 
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "claude-usage-phuryn",
   "displayName": "Claude Code Usage by Paweł Huryn",
   "description": "Embed your Claude Code usage dashboard (token counts, costs, sessions, projects) directly inside VS Code. Reads local JSONL transcripts, no API calls.",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "publisher": "PawelHuryn",
   "author": {
     "name": "Paweł Huryn",


### PR DESCRIPTION
## The bug

Most of my subagent dispatches show as **`unknown`** in *Top Subagent Dispatches* and in the by-type breakdown, even though the transcripts clearly identify them.

`extract_agent_dispatch` learns an agent's name from the parent's closing `toolUseResult`, which carries `agentType` only when the dispatch ran **synchronously and completed**. A background (`isAsync`) dispatch logs a launch record instead:

```json
{"isAsync": true, "status": "async_launched", "agentId": "a777b13086edbcf85",
 "description": "...", "resolvedModel": "claude-sonnet-5", "prompt": "..."}
```

No `agentType`. So those agents never get a row in `agents`, the `LEFT JOIN` misses, and `AGENT_TYPE_EXPR` falls through to `'unknown'`.

Across my transcript tree (2,123 files), of 120 parent records carrying an `agentId`:

| status | count | has `agentType` |
|---|---:|---|
| `completed` | 40 | yes |
| `async_launched` | 80 | **no** |

Two thirds of dispatches were unnameable from the parent side alone.

## The fix

Every assistant record inside the subagent's **own** jsonl carries `attributionAgent` alongside `agentId` — the same human-readable name (`general-purpose`, `Explore`, plugin agents like `health:coach`). It is present regardless of how the dispatch was launched or whether it ever finished, so it recovers the name in exactly the cases the parent record can't.

- New `extract_agent_attribution()` returns a **name-only** record, tagged `source: "attribution"`.
- `upsert_agents()` now routes by `source`: full dispatch records overwrite every column as before; attribution records use `COALESCE(NULLIF(agents.agent_type, ''), excluded.agent_type)` so they **never clobber** a name learned from a parent `agentType`. Dispatches are applied first, so the outcome doesn't depend on file scan order.
- Wired into both parse paths (`parse_jsonl_file` and the incremental tail parser in `scan()`).

## Backfill

Files already in `processed_files` are skipped by an incremental scan, so existing databases would keep showing `unknown` indefinitely. `_backfill_agent_types()` mirrors the existing `_backfill_topics()` exactly — gated on a `schema_meta` marker (`agent_type_backfill_done`), re-reads only `attributionAgent` records with a cheap substring prefilter, and **leaves `turns` untouched so token totals cannot drift**.

## Verification

On a real 2,123-file transcript tree, before → after:

```
TYPE               dispatches        tokens
general-purpose            33    69,587,479
archivist                  38    68,021,644
health:coach               28    34,735,377
health:medic               18    29,085,953
Explore                    10     9,695,270
herald                      4     2,940,891
claude                      1     1,408,369
ari:ari                     2       753,841
```

All 134 dispatches named, zero `unknown` — where only 40 were reachable from a parent `agentType`.

The backfill path was exercised on a simulated pre-fix database: 40 → 134 named agents with **0 new/updated files** (2,122 skipped), confirming it works without a rescan.

## Tests

6 new tests in `tests/test_subagent.py` (`TestAgentAttribution`), covering extraction, the both-fields-required guard, parse capture, dispatch-name-wins precedence, the async end-to-end case, and the backfill on an already-scanned DB. Full suite: **153 passed**.

## Versioning

Added a `## v1.5.6 — TBD` heading with the CHANGELOG bullets and bumped `scanner.VERSION` + `vscode-extension/package.json` in lockstep, since `tests/test_version.py` enforces parity. Happy to change the bump level or drop the heading entirely if you'd rather write it yourself at release time.

---

_Written with an agent, reviewed by Reto._
