### PR TITLE
Agent/skill/mcp/hook attribution, worktree-aware projects, cost breakdown UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,10 @@ python cli.py scan                  # incremental scan (fast on re-run)
 python cli.py today                 # today's usage by model
 python cli.py week                  # last 7 days, per-day + by-model
 python cli.py stats                 # all-time stats
-python cli.py dashboard             # scan + open http://localhost:8080
-python cli.py scan --projects-dir PATH    # scan a custom transcripts dir
+python cli.py dashboard                          # scan + open http://localhost:8080
+python cli.py dashboard --host 0.0.0.0 --port 9000
+python cli.py scan --projects-dir PATH           # scan a custom transcripts dir
+# or via env vars:
 HOST=0.0.0.0 PORT=9000 python cli.py dashboard
 
 python -m unittest discover -s tests -v             # full test suite (CI runs this)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v1.5.5 — 2026-07-10
+
+### Dashboard
+
+- Added an **Est. Cost line overlay** to the Daily Token Usage chart — a legend-toggleable line on a dedicated right-hand axis, priced **per model before the daily aggregation** so multi-model days are costed correctly (#151, thanks @paulabenzar).
+- Fixed **"This Month"** (and the other calendar ranges) including the previous month's last day in UTC+ timezones: date-range bounds are now formatted from local calendar components instead of `toISOString()` (UTC). The same local-date helper is now used by `rangeIncludesToday`, so it can no longer disagree with the range bounds near UTC midnight (#151, thanks @paulabenzar).
+
+### Scanner / CLI
+
+- The `today`, `week`, and `stats` commands now run the idempotent schema migration when they open the database, so reading before the next `scan` no longer crashes with `sqlite3.OperationalError: no such column: is_subagent` on a database created before subagent tracking existed. The dashboard already did this; the CLI read path now matches (#153, thanks @iliaal).
+
+### Project / docs
+
+- Documented the `dashboard` command's `--host` / `--port` flags in the README and AGENTS.md — the flags already worked (and are shown in the built-in `USAGE` text) but only the `HOST` / `PORT` environment variables were documented (#150, thanks @subhamchbty).
+
 ## v1.5.4 — 2026-07-01
 
 ### Dashboard

--- a/Formula/claude-usage.rb
+++ b/Formula/claude-usage.rb
@@ -6,9 +6,9 @@ class ClaudeUsage < Formula
   # sha256 would be uncomputable (the tarball would contain this very hash).
   # It therefore tracks one release behind by design — bump to the prior tag
   # each release. See AGENTS.md "Homebrew formula and self-referential SHA".
-  url "https://github.com/phuryn/claude-usage/archive/refs/tags/v1.5.1.tar.gz"
-  version "1.5.1"
-  sha256 "88224cf583a04863942c5246e2e35d901bf60738dbe3352567ef6c749af9730d"
+  url "https://github.com/phuryn/claude-usage/archive/refs/tags/v1.5.4.tar.gz"
+  version "1.5.4"
+  sha256 "c43337fa785e4e78ecdb6da3ab5b1cb7aa780aad8096790fdf3a152441be5550"
   license "MIT"
   head "https://github.com/phuryn/claude-usage.git", branch: "main"
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ python cli.py stats
 # Scan + open browser dashboard at http://localhost:8080
 python cli.py dashboard
 
-# Custom host and port via environment variables
+# Custom host and port
+python cli.py dashboard --host 0.0.0.0 --port 9000
+
+# Environment variables are also supported
 HOST=0.0.0.0 PORT=9000 python cli.py dashboard
 
 # Scan a custom projects directory
@@ -133,7 +136,7 @@ Claude Code writes one JSONL file per session to `~/.claude/projects/`. Each lin
 
 `scanner.py` parses those files and stores the data in a SQLite database at `~/.claude/usage.db`.
 
-`dashboard.py` serves a single-page dashboard on `localhost:8080` with Chart.js charts (loaded from CDN). It auto-refreshes every 30 seconds and supports model filtering and a date-range dropdown with bookmarkable URLs. A sticky section nav jumps between sections, and every chart/table can be collapsed (remembered across reloads). The bind address and port can be overridden with `HOST` and `PORT` environment variables (defaults: `localhost`, `8080`).
+`dashboard.py` serves a single-page dashboard on `localhost:8080` with Chart.js charts (loaded from CDN). It auto-refreshes every 30 seconds and supports model filtering and a date-range dropdown with bookmarkable URLs. A sticky section nav jumps between sections, and every chart/table can be collapsed (remembered across reloads). The bind address and port can be configured with the `--host` and `--port` flags, or the `HOST` and `PORT` environment variables (defaults: `localhost`, `8080`).
 
 ---
 

--- a/cli.py
+++ b/cli.py
@@ -83,7 +83,17 @@ def require_db():
     if not DB_PATH.exists():
         print("Database not found. Run: python cli.py scan")
         sys.exit(1)
-    return sqlite3.connect(DB_PATH)
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    # Ensure the schema is current before querying. The read commands query the
+    # `agents` table and the `is_subagent`/`agent_id` columns, so a pre-existing
+    # DB from before those were added would raise "no such column" when a read
+    # command runs before the next scan migrates it. init_db is idempotent
+    # (CREATE ... IF NOT EXISTS + additive column checks), so this is a cheap
+    # no-op once migrated. Mirrors get_dashboard_data in dashboard.py.
+    from scanner import init_db
+    init_db(conn)
+    return conn
 
 
 # ── Commands ──────────────────────────────────────────────────────────────────
@@ -95,7 +105,6 @@ def cmd_scan(projects_dir=None):
 
 def cmd_today():
     conn = require_db()
-    conn.row_factory = sqlite3.Row
     today = date.today().isoformat()
 
     rows = conn.execute("""
@@ -164,7 +173,6 @@ def cmd_today():
 
 def cmd_week():
     conn = require_db()
-    conn.row_factory = sqlite3.Row
 
     today_d = date.today()
     start_d = today_d - timedelta(days=6)
@@ -260,7 +268,6 @@ def cmd_week():
 
 def cmd_stats():
     conn = require_db()
-    conn.row_factory = sqlite3.Row
 
     # Session-level info (count, date range)
     session_info = conn.execute("""

--- a/dashboard.py
+++ b/dashboard.py
@@ -884,10 +884,16 @@ const RANGE_LABELS = { 'today': 'Today', 'week': 'This Week', 'month': 'This Mon
 const RANGE_TICKS  = { 'today': 1, 'week': 7, 'month': 15, 'prev-month': 15, '7d': 7, '30d': 15, '90d': 13, 'all': 12 };
 const VALID_RANGES = Object.keys(RANGE_LABELS);
 
+// Local calendar date as YYYY-MM-DD. NOT toISOString(), which formats in UTC and
+// shifts the day back in UTC+ timezones (that was the "This Month" bug, #151).
+function localISODate(d) {
+  return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+}
+
 function rangeIncludesToday(range) {
   if (range === 'all') return true;
   const { start, end } = getRangeBounds(range);
-  const today = new Date().toISOString().slice(0, 10);
+  const today = localISODate(new Date());
   if (start && today < start) return false;
   if (end && today > end) return false;
   return true;
@@ -896,7 +902,7 @@ function rangeIncludesToday(range) {
 function getRangeBounds(range) {
   if (range === 'all') return { start: null, end: null };
   const today = new Date();
-  const iso = d => d.toISOString().slice(0, 10);
+  const iso = localISODate;
   if (range === 'today') {
     const t = iso(today);
     return { start: t, end: t };
@@ -1172,12 +1178,13 @@ function applyFilter() {
   // Daily chart: aggregate by day
   const dailyMap = {};
   for (const r of filteredDaily) {
-    if (!dailyMap[r.day]) dailyMap[r.day] = { day: r.day, input: 0, output: 0, cache_read: 0, cache_creation: 0 };
+    if (!dailyMap[r.day]) dailyMap[r.day] = { day: r.day, input: 0, output: 0, cache_read: 0, cache_creation: 0, cost: 0 };
     const d = dailyMap[r.day];
     d.input          += r.input;
     d.output         += r.output;
     d.cache_read     += r.cache_read;
     d.cache_creation += r.cache_creation;
+    d.cost           += calcCost(r.model, r.input, r.output, r.cache_read, r.cache_creation);
   }
   const daily = Object.values(dailyMap).sort((a, b) => a.day.localeCompare(b.day));
 
@@ -1446,15 +1453,24 @@ function renderDailyChart(daily) {
         { label: 'Output',         hidden: hiddenSeries.daily.has('Output'),         data: daily.map(d => d.output),         backgroundColor: TOKEN_COLORS.output,         hoverBackgroundColor: TOKEN_HOVER.output,         stack: 'io',    yAxisID: 'y1' },
         { label: 'Cache Read',     hidden: hiddenSeries.daily.has('Cache Read'),     data: daily.map(d => d.cache_read),     backgroundColor: TOKEN_COLORS.cache_read,     hoverBackgroundColor: TOKEN_HOVER.cache_read,     stack: 'cache', yAxisID: 'y' },
         { label: 'Cache Creation', hidden: hiddenSeries.daily.has('Cache Creation'), data: daily.map(d => d.cache_creation), backgroundColor: TOKEN_COLORS.cache_creation, hoverBackgroundColor: TOKEN_HOVER.cache_creation, stack: 'cache', yAxisID: 'y' },
+        { type: 'line', label: 'Est. Cost', hidden: hiddenSeries.daily.has('Est. Cost'), data: daily.map(d => d.cost), borderColor: C.accent, backgroundColor: 'transparent', pointBackgroundColor: C.accent, pointRadius: 3, tension: 0.3, yAxisID: 'y2' },
       ]
     },
     options: {
       responsive: true, maintainAspectRatio: false, resizeDelay: 150,
-      plugins: { legend: { onClick: legendToggle('daily'), labels: { color: C.axis, boxWidth: 12 } } },
+      plugins: {
+        legend: { onClick: legendToggle('daily'), labels: { color: C.axis, boxWidth: 12 } },
+        tooltip: { callbacks: {
+          label: item => item.dataset.label === 'Est. Cost'
+            ? ` Est. Cost: ${fmtCost(item.raw)}`
+            : ` ${item.dataset.label}: ${fmt(item.raw)}`
+        }}
+      },
       scales: {
-        x: { ticks: { color: C.axis, maxTicksLimit: RANGE_TICKS[selectedRange] }, grid: { color: C.border } },
-        y:  { position: 'left',  ticks: { color: C.green, callback: v => fmt(v) }, grid: { color: C.border }, title: { display: true, text: 'Cache', color: C.green } },
-        y1: { position: 'right', ticks: { color: C.blue, callback: v => fmt(v) }, grid: { drawOnChartArea: false },    title: { display: true, text: 'Input / Output', color: C.blue } },
+        x:  { ticks: { color: C.axis, maxTicksLimit: RANGE_TICKS[selectedRange] }, grid: { color: C.border } },
+        y:  { position: 'left',  ticks: { color: C.green,  callback: v => fmt(v) },         grid: { color: C.border },          title: { display: true, text: 'Cache',         color: C.green } },
+        y1: { position: 'right', ticks: { color: C.blue,   callback: v => fmt(v) },         grid: { drawOnChartArea: false },    title: { display: true, text: 'Input / Output', color: C.blue } },
+        y2: { position: 'right', ticks: { color: C.accent, callback: v => '$' + v.toFixed(2) }, grid: { drawOnChartArea: false }, title: { display: true, text: 'Est. Cost', color: C.accent }, offset: true },
       }
     }
   });

--- a/scanner.py
+++ b/scanner.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 # runtime version has to live here as a constant. Keep this in lockstep with the
 # top CHANGELOG heading and vscode-extension/package.json (a parity test guards
 # all three; see tests/test_version.py).
-VERSION = "1.5.4"
+VERSION = "1.5.5"
 
 PROJECTS_DIR = Path.home() / ".claude" / "projects"
 XCODE_PROJECTS_DIR = Path.home() / "Library" / "Developer" / "Xcode" / "CodingAssistant" / "ClaudeAgentConfig" / "projects"

--- a/tests/test_cli_subagent.py
+++ b/tests/test_cli_subagent.py
@@ -64,5 +64,56 @@ class TestCliSubagentLines(unittest.TestCase):
         self.assertIn("Subagent tokens:", out)
 
 
+class TestCliReadCommandsMigrateOldSchema(unittest.TestCase):
+    """A DB created before the subagent columns existed must not crash the read
+    commands: require_db runs the idempotent init_db migration on open."""
+
+    def setUp(self):
+        import sqlite3
+        self.db_path = Path(tempfile.mkdtemp()) / "usage.db"
+        today_ts = date.today().isoformat() + "T10:00:00Z"
+        # Pre-migration schema: turns has no is_subagent/agent_id, and there is
+        # no `agents` table.
+        conn = sqlite3.connect(self.db_path)
+        conn.executescript("""
+            CREATE TABLE turns (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT,
+                timestamp TEXT, model TEXT, input_tokens INTEGER,
+                output_tokens INTEGER, cache_read_tokens INTEGER,
+                cache_creation_tokens INTEGER, tool_name TEXT, cwd TEXT,
+                message_id TEXT);
+        """)
+        conn.execute(
+            "INSERT INTO turns (session_id, timestamp, model, input_tokens, "
+            "output_tokens, cache_read_tokens, cache_creation_tokens, message_id) "
+            "VALUES ('s1', ?, 'claude-opus-4-8', 100, 200, 0, 0, 'm1')",
+            (today_ts,))
+        conn.commit()
+        conn.close()
+        self._orig_db = cli.DB_PATH
+        cli.DB_PATH = self.db_path
+
+    def tearDown(self):
+        cli.DB_PATH = self._orig_db
+
+    def test_today_does_not_crash_on_old_schema(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cli.cmd_today()
+        self.assertIn("Subagent tokens:", buf.getvalue())
+
+    def test_week_does_not_crash_on_old_schema(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cli.cmd_week()
+        self.assertTrue(buf.getvalue())
+
+    def test_stats_does_not_crash_on_old_schema(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cli.cmd_stats()
+        self.assertIn("Subagent turns:", buf.getvalue())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "claude-usage-phuryn",
   "displayName": "Claude Code Usage by Paweł Huryn",
   "description": "Embed your Claude Code usage dashboard (token counts, costs, sessions, projects) directly inside VS Code. Reads local JSONL transcripts, no API calls.",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "publisher": "PawelHuryn",
   "author": {
     "name": "Paweł Huryn",


### PR DESCRIPTION
## Summary
- Captures per-turn attribution (agent, skill, plugin, MCP server/tool, thread type) from the JSONL records' `attributionAgent`/`attributionSkill`/`attributionMcpServer`/`attributionMcpTool`/`origin.kind`, plus a new `python cli.py breakdown` command and a "Usage Breakdown" dashboard table (agent/skill/mcp/thread x model/day/month, with CSV export).
- Fixes project names fragmenting across git worktrees by resolving each cwd's actual repo root via `.git`'s `commondir`, with a one-time backfill for existing DBs.
- Tracks hook-injected context (new `hook_events` table, parsed from `hook_success` attachment records' `additionalContext`), surfaced as a "Context Injected by Hooks" chart plus a by-source (plugin/script) drilldown, with a backfill for existing scans.
- Adds Active/Background/Token/Cache cost stat cards, Cost by Thread Type and Cost by Activity doughnuts, percentages on every chart tooltip, and a "% of Total" column on the cost-bearing tables (Cost by Model/Project/Project+Branch, Recent Sessions, Top Subagent Dispatches, Usage Breakdown).
- Bumps to v1.6.0 (`scanner.VERSION`, `vscode-extension/package.json`, CHANGELOG) in lockstep per the version-parity test.

## Test plan
- [x] `python -m unittest discover -s tests -v` — 191 tests passing, including 3 new test files (`test_breakdown.py`, `test_git_worktrees.py`, `test_hook_events.py`) covering the new attribution columns, real `git worktree add` scenarios, and hook-injection extraction/backfill/dedup.
- [x] Verified the new dashboard cards/charts/tables against a real `~/.claude/usage.db` in a browser (Playwright), including hovering chart tooltips to confirm percentages compute correctly.